### PR TITLE
Fprime vscode managed profiles

### DIFF
--- a/pkg/host/profile_registry.go
+++ b/pkg/host/profile_registry.go
@@ -273,18 +273,6 @@ func (r *profileRegistry) Remove(id string) error {
 		return fmt.Errorf("no profile with id %s", id)
 	}
 
-	if _, isRuntimeProfile := profile.(RuntimeProfile); isRuntimeProfile {
-		if _, isNonPersistent := profile.(*nonPersistentProfile); !isNonPersistent {
-			r.logger.Warn(
-				"attempted to remove runtime profile. forbidden operation",
-				"name", profile.Name(),
-				"provider", profile.Config().Provider,
-				"id", id,
-			)
-			return fmt.Errorf("cannot remove profile with id %s", id)
-		}
-	}
-
 	r.logger.Info(
 		"removing profile",
 		"name", profile.Name(),

--- a/pkg/rpc/api.go
+++ b/pkg/rpc/api.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	grpcpb "github.com/nasa/hermes/pkg/grpc"
@@ -738,6 +739,12 @@ func (r *apiServer) StopProfile(ctx context.Context, id *pb.Id) (*emptypb.Empty,
 		return nil, err
 	}
 
+	// Runtime profiles are not configurable by the user
+	// We should not allow the profile to fall into idle state
+	if rProf, ok := prof.(host.RuntimeProfile); ok {
+		host.Profiles.RemoveRuntime(rProf)
+	}
+
 	return &emptypb.Empty{}, nil
 }
 
@@ -934,11 +941,44 @@ func (r *apiServer) SubscribeFsw(_ *emptypb.Empty, s grpc.ServerStreamingServer[
 
 // SubscribeProfiles implements pb.ApiServer.
 func (r *apiServer) SubscribeProfiles(_ *emptypb.Empty, s grpc.ServerStreamingServer[pb.ProfileList]) error {
+	var (
+		mu           sync.Mutex
+		timer        *time.Timer
+		pendingState map[string]*pb.StatefulProfile
+	)
+
 	host.Profiles.ProfileState.Subscribe(s.Context(), func(sp map[string]*pb.StatefulProfile) {
-		s.Send(&pb.ProfileList{All: sp})
+		mu.Lock()
+		defer mu.Unlock()
+
+		// Store the latest state
+		pendingState = sp
+
+		// Reset or create the debounce timer
+		if timer != nil {
+			timer.Stop()
+		}
+
+		timer = time.AfterFunc(20*time.Millisecond, func() {
+			mu.Lock()
+			stateToSend := pendingState
+			mu.Unlock()
+
+			if stateToSend != nil {
+				s.Send(&pb.ProfileList{All: stateToSend})
+			}
+		})
 	})
 
 	<-s.Context().Done()
+
+	// Clean up timer on context cancellation
+	mu.Lock()
+	if timer != nil {
+		timer.Stop()
+	}
+	mu.Unlock()
+
 	return nil
 }
 

--- a/src/extensions/core/src/components/ConnectionViewer.ts
+++ b/src/extensions/core/src/components/ConnectionViewer.ts
@@ -170,7 +170,7 @@ export class ConnectionViewer extends WebViewPanelBase implements vscode.Webview
                         await this.api.addProfile({
                             name: msg.provider,
                             provider: msg.provider,
-                            setting: "{}",
+                            settings: "{}",
                         }, token);
                         break;
                     case "profileStart":
@@ -238,7 +238,7 @@ export class ConnectionViewer extends WebViewPanelBase implements vscode.Webview
                         return assertUnreachable(msg);
                 }
             } catch (err) {
-                vscode.window.showErrorMessage(String(err));
+                vscode.window.showErrorMessage(`Hermes: (${msg.type}) ${err}`);
             }
         }, webviewView.webview);
 

--- a/src/extensions/fprime/package.json
+++ b/src/extensions/fprime/package.json
@@ -190,19 +190,9 @@
                             }
                         }
                     },
-                    "autoStartProfile": {
-                        "type": "boolean",
-                        "description": "Whether to auto-start the profile",
-                        "default": true
-                    },
                     "fswCommand": {
                         "type": "string",
                         "description": "FSW binary command (optional, for reference)"
-                    },
-                    "startFsw": {
-                        "type": "boolean",
-                        "description": "Whether to start FSW (note: FSW should be started via separate shell task)",
-                        "default": false
                     }
                 }
             }

--- a/src/extensions/fprime/src/task.ts
+++ b/src/extensions/fprime/src/task.ts
@@ -36,20 +36,10 @@ export interface FprimeDeploymentTaskDefinition {
     };
 
     /**
-     * Whether to auto-start the profile (default: true)
-     */
-    autoStartProfile?: boolean;
-
-    /**
      * FSW binary path (optional)
      * If provided, will start FSW after profile is created
      */
     fswCommand?: string;
-
-    /**
-     * Whether to start FSW (default: false)
-     */
-    startFsw?: boolean;
 }
 
 /**
@@ -111,9 +101,6 @@ class FprimeDeploymentPseudoTerminal implements vscode.Pseudoterminal {
             )
         });
 
-        const autoStartProfile = this.def.autoStartProfile ?? true;
-        const startFsw = this.def.startFsw ?? false;
-
         try {
             // Step 1: Create and start profile
             this.logger.info(`Creating profile: ${this.def.title}`);
@@ -138,22 +125,13 @@ class FprimeDeploymentPseudoTerminal implements vscode.Pseudoterminal {
                     } catch (err) {
                         this.logger.error(`failed to stop profile on close: ${err}`);
                     }
-
-                    try {
-                        await this.api.removeProfile(profileId);
-                    } catch  (err) {
-                        this.logger.error(`failed to remove profile on close: ${err}`);
-                    }
                 }
             });
 
             this.logger.info(`Profile created successfully with ID: ${this.profileId}`);
-
-            if (autoStartProfile) {
-                this.logger.info(`Starting profile...`);
-                await this.api.startProfile(this.profileId);
-                this.logger.info(`Profile started successfully`);
-            }
+            this.logger.info(`Starting profile...`);
+            await this.api.startProfile(this.profileId);
+            this.logger.info(`Profile started successfully`);
         } catch (err) {
             this.logger.error(`Failed to create/start deployment: ${err}`);
             this._onDidClose.fire(1);
@@ -161,7 +139,7 @@ class FprimeDeploymentPseudoTerminal implements vscode.Pseudoterminal {
         }
 
         // Step 2: Start FSW if requested
-        if (startFsw && this.def.fswCommand) {
+        if (this.def.fswCommand) {
             this.logger.info(`Starting FSW: ${this.def.fswCommand}`);
 
             try {
@@ -310,9 +288,7 @@ export class FprimeDeploymentProvider implements vscode.TaskProvider {
                             dictionary: deploymentName,
                             protocol: 'ccsds',
                         },
-                        autoStartProfile: true,
                         fswCommand: `\${workspaceFolder}/${binaryPath} -a 0.0.0.0 -p ${basePort}`,
-                        startFsw: true,
                     };
 
                     const task = new vscode.Task(


### PR DESCRIPTION
This PR adds the following:

1. Ability to create "non-persistent" dictionaries and profiles. Do this by specifying an ID in those protobuf objects. These will not be stored or managed by Hermes's storage system
2. Auto-detect and run F Prime deployments through VSCode tasks
3. Auto-detect and register F Prime dictionaries in the workspace

https://github.com/user-attachments/assets/794dfd77-664d-47ad-a048-ec37f1889980

