### PR TITLE
Implement Add Remote Host Flow

### DIFF
--- a/src/extensions/core/src/api/Remote.ts
+++ b/src/extensions/core/src/api/Remote.ts
@@ -368,7 +368,13 @@ async function pickRemoteDialog(current?: Settings.Remote): Promise<Settings.Rem
     if (pick?.remote) {
         return pick.remote;
     } else if (pick?.createNew) {
-        return await createNewRemoteDialog();
+        const newRemote = await createNewRemoteDialog();
+        if (!newRemote) return undefined;
+        const connect = await vscode.window.showInformationMessage(
+            `Remote "${newRemote.label}" added. Connect to it now?`,
+            "Connect", "Not now"
+        );
+        return connect === "Connect" ? newRemote : undefined;
     }
 }
 

--- a/src/extensions/core/src/api/Remote.ts
+++ b/src/extensions/core/src/api/Remote.ts
@@ -373,10 +373,17 @@ async function pickRemoteDialog(current?: Settings.Remote): Promise<Settings.Rem
 }
 
 async function createNewRemoteDialog(): Promise<Settings.Remote | undefined> {
+    const existingRemotes = Settings.hostRemotes();
     const label = await vscode.window.showInputBox({
         title: "New Hermes Remote",
         prompt: "Enter a label for this remote",
         placeHolder: "e.g. Local TCP",
+        validateInput: (v) => {
+            if (v && !/^[a-zA-Z0-9_ ]+$/.test(v)) return "Label may only contain letters, numbers, spaces, and underscores";
+            const key = v.toLowerCase().replace(/\s+/g, '-');
+            if (key && existingRemotes[key]) return `Label "${v}" is already in use`;
+            return undefined;
+        },
     });
     if (label === undefined) return undefined;
  
@@ -422,7 +429,7 @@ async function createNewRemoteDialog(): Promise<Settings.Remote | undefined> {
     });
     if (!authPick) return undefined;
  
-    const key = label.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '') || Date.now().toString();
+    const key = label.toLowerCase().replace(/\s+/g, '-') || Date.now().toString();
     const remote: Settings.Remote = {
         key,
         label,

--- a/src/extensions/core/src/api/Remote.ts
+++ b/src/extensions/core/src/api/Remote.ts
@@ -390,16 +390,19 @@ async function createNewRemoteDialog(): Promise<Settings.Remote | undefined> {
     const url = await vscode.window.showInputBox({
         title: "New Hermes Remote",
         prompt: "Enter the Hermes backend URL",
-        placeHolder: "e.g. http://localhost:6880",
+        value: "http://localhost:6880",
         validateInput: (v) => {
-            if (!v) return "URL is required";
-            try { new URL(v); return undefined; } catch { return "Must be a valid URL (e.g. http://localhost:6880)"; }
+            const trimmed = v.trim();
+            if (!trimmed) return "URL is required";
+            try { new URL(trimmed); return undefined; } catch { return "Must be a valid URL (e.g. http://localhost:6880)"; }
         },
     });
     if (!url) return undefined;
  
     type AuthPick = vscode.QuickPickItem & { value: Rpc.HostAuthenticationKind; disabled?: boolean };
-    const isHttps = url.toLowerCase().startsWith("https://");
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) return undefined;
+    const isHttps = trimmedUrl.toLowerCase().startsWith("https://");
     const authPick = await new Promise<AuthPick | undefined>((resolve) => {
         const qp = vscode.window.createQuickPick<AuthPick>();
         qp.title = "Authentication Method";
@@ -433,7 +436,7 @@ async function createNewRemoteDialog(): Promise<Settings.Remote | undefined> {
     const remote: Settings.Remote = {
         key,
         label,
-        url,
+        url: trimmedUrl,
         authenticationMethod: authPick.value,
         skipTLSVerify: false,
     };

--- a/src/extensions/core/src/api/Remote.ts
+++ b/src/extensions/core/src/api/Remote.ts
@@ -368,13 +368,7 @@ async function pickRemoteDialog(current?: Settings.Remote): Promise<Settings.Rem
     if (pick?.remote) {
         return pick.remote;
     } else if (pick?.createNew) {
-        const newRemote = await createNewRemoteDialog();
-        if (!newRemote) return undefined;
-        const connect = await vscode.window.showInformationMessage(
-            `Remote "${newRemote.label}" added. Connect to it now?`,
-            "Connect", "Not now"
-        );
-        return connect === "Connect" ? newRemote : undefined;
+        return await createNewRemoteDialog();
     }
 }
 

--- a/src/extensions/core/src/api/Remote.ts
+++ b/src/extensions/core/src/api/Remote.ts
@@ -384,16 +384,42 @@ async function createNewRemoteDialog(): Promise<Settings.Remote | undefined> {
         title: "New Hermes Remote",
         prompt: "Enter the Hermes backend URL",
         placeHolder: "e.g. http://localhost:6880",
-        validateInput: (v) => v ? undefined : "URL is required",
+        validateInput: (v) => {
+            if (!v) return "URL is required";
+            try { new URL(v); return undefined; } catch { return "Must be a valid URL (e.g. http://localhost:6880)"; }
+        },
     });
     if (!url) return undefined;
  
-    type AuthPick = vscode.QuickPickItem & { value: Rpc.HostAuthenticationKind };
-    const authPick = await vscode.window.showQuickPick<AuthPick>([
-        { label: "None", value: Rpc.HostAuthenticationKind.NONE },
-        { label: "Username / Password", value: Rpc.HostAuthenticationKind.USER_PASS },
-        { label: "Token", value: Rpc.HostAuthenticationKind.TOKEN },
-    ], { title: "Authentication Method" });
+    type AuthPick = vscode.QuickPickItem & { value: Rpc.HostAuthenticationKind; disabled?: boolean };
+    const isHttps = url.toLowerCase().startsWith("https://");
+    const authPick = await new Promise<AuthPick | undefined>((resolve) => {
+        const qp = vscode.window.createQuickPick<AuthPick>();
+        qp.title = "Authentication Method";
+        qp.items = [
+            { label: "None", value: Rpc.HostAuthenticationKind.NONE },
+            {
+                label: "Username / Password",
+                description: isHttps ? undefined : "$(lock) Requires HTTPS",
+                value: Rpc.HostAuthenticationKind.USER_PASS,
+                disabled: !isHttps,
+            },
+            {
+                label: "Token",
+                description: isHttps ? undefined : "$(lock) Requires HTTPS",
+                value: Rpc.HostAuthenticationKind.TOKEN,
+                disabled: !isHttps,
+            },
+        ];
+        qp.onDidAccept(() => {
+            const selected = qp.selectedItems[0];
+            if (!selected || selected.disabled) return;
+            resolve(selected);
+            qp.dispose();
+        });
+        qp.onDidHide(() => { resolve(undefined); qp.dispose(); });
+        qp.show();
+    });
     if (!authPick) return undefined;
  
     const key = label.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '') || Date.now().toString();

--- a/src/extensions/core/src/api/Remote.ts
+++ b/src/extensions/core/src/api/Remote.ts
@@ -278,17 +278,22 @@ function remoteToQuickPickItem(key: string, remote: Settings.Remote): RemoteQuic
         description: saneRemote.url,
         detail: errors.length > 0 ? ("$(alert) Invalid Remote: " + errors.join(". ")) : undefined,
         remote: saneRemote,
-        invalid: errors.length > 0
+        invalid: errors.length > 0,
+        buttons: [{ iconPath: new vscode.ThemeIcon("trash"), tooltip: "Remove remote" }]
     };
 }
 
 
 async function pickRemoteDialog(current?: Settings.Remote): Promise<Settings.Remote | undefined> {
-    const remotes = Settings.hostRemotes();
     const quickPick = vscode.window.createQuickPick<RemoteQuickPickItem>();
     quickPick.canSelectMany = false;
 
-    const remoteQuickPickItems = Array.from(Object.entries(remotes).map(([key, remote]) => remoteToQuickPickItem(key, remote)));
+    const buildItems = (currentRemotes = Settings.hostRemotes()): RemoteQuickPickItem[] => [
+        ...Object.entries(currentRemotes).map(([key, remote]) => remoteToQuickPickItem(key, remote)),
+        { label: "", kind: vscode.QuickPickItemKind.Separator },
+        { iconPath: new vscode.ThemeIcon("plus"), label: "Add new Hermes remote", alwaysShow: true, createNew: true },
+    ];
+
     quickPick.title = "Select a Hermes remote host to connect to";
     quickPick.buttons = [
         {
@@ -297,21 +302,9 @@ async function pickRemoteDialog(current?: Settings.Remote): Promise<Settings.Rem
             tooltip: "Edit Remote Settings"
         }
     ];
-    quickPick.items = [
-        ...remoteQuickPickItems,
-        {
-            label: "",
-            kind: vscode.QuickPickItemKind.Separator,
-        },
-        {
-            iconPath: new vscode.ThemeIcon("plus"),
-            label: "Add new Hermes remote",
-            alwaysShow: true,
-            createNew: true,
-        }
-    ];
+    quickPick.items = buildItems();
 
-    const selected = remoteQuickPickItems.find((v) => {
+    const selected = quickPick.items.find((v) => {
         if (v.remote && current) {
             return current.key === v.remote.key;
         } else {
@@ -327,6 +320,21 @@ async function pickRemoteDialog(current?: Settings.Remote): Promise<Settings.Rem
         subs.push(
             quickPick.onDidHide(() => {
                 resolve(undefined);
+            }),
+            quickPick.onDidTriggerItemButton(async ({ item }) => {
+                // There is only one button
+                // [Trash Button]
+                if (item.remote?.key) {
+                    const updatedRemotes = { ...Settings.hostRemotes() };
+                    delete updatedRemotes[item.remote.key];
+                    await vscode.workspace.getConfiguration().update(
+                        Settings.names.host.remotes,
+                        updatedRemotes,
+                        vscode.ConfigurationTarget.Workspace
+                    );
+                    quickPick.items = buildItems(updatedRemotes);
+                }
+                // Rebuild items list without removed item
             }),
             quickPick.onDidAccept(() => {
                 if (quickPick.selectedItems.length > 0) {

--- a/src/extensions/core/src/api/Remote.ts
+++ b/src/extensions/core/src/api/Remote.ts
@@ -365,5 +365,45 @@ async function pickRemoteDialog(current?: Settings.Remote): Promise<Settings.Rem
 }
 
 async function createNewRemoteDialog(): Promise<Settings.Remote | undefined> {
-    return undefined;
+    const label = await vscode.window.showInputBox({
+        title: "New Hermes Remote",
+        prompt: "Enter a label for this remote",
+        placeHolder: "e.g. Local TCP",
+    });
+    if (label === undefined) return undefined;
+ 
+    const url = await vscode.window.showInputBox({
+        title: "New Hermes Remote",
+        prompt: "Enter the Hermes backend URL",
+        placeHolder: "e.g. http://localhost:6880",
+        validateInput: (v) => v ? undefined : "URL is required",
+    });
+    if (!url) return undefined;
+ 
+    type AuthPick = vscode.QuickPickItem & { value: Rpc.HostAuthenticationKind };
+    const authPick = await vscode.window.showQuickPick<AuthPick>([
+        { label: "None", value: Rpc.HostAuthenticationKind.NONE },
+        { label: "Username / Password", value: Rpc.HostAuthenticationKind.USER_PASS },
+        { label: "Token", value: Rpc.HostAuthenticationKind.TOKEN },
+    ], { title: "Authentication Method" });
+    if (!authPick) return undefined;
+ 
+    const key = label.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '') || Date.now().toString();
+    const remote: Settings.Remote = {
+        key,
+        label,
+        url,
+        authenticationMethod: authPick.value,
+        skipTLSVerify: false,
+    };
+ 
+    const remotes = Settings.hostRemotes();
+    remotes[key] = remote;
+    await vscode.workspace.getConfiguration().update(
+        Settings.names.host.remotes,
+        remotes,
+        vscode.ConfigurationTarget.Workspace
+    );
+ 
+    return remote;
 }


### PR DESCRIPTION
## Changes
Implemented `createNewRemoteDialog()`. This allows the user to add new Remote Hosts via the VSCode Extension GUI, instead of manually updating `settings.json`.
### Features
- Input-controlled prompt for user to label the remote for readability (restricts to alphanumeric + spaces/underscores)
- Prevents re-used labels and indicates this to the user before submission
- URL entry verification (prevents submission on non-URL)
- Visually and Functionally disables selection of `USERPASS`/`TOKEN` when non-HTTPS is used for URL
- Added Host Deletion via trash icon in Host Menu

> [!WARNING]
> `skipTLSVerify` is currently hard-coded to `false`. 
## Screenshots
<img width="600" height="63" alt="Screenshot 2026-06-23 at 3 59 30 PM" src="https://github.com/user-attachments/assets/e2bb9a16-43c4-4cf4-a823-54592eeb87f1" />
<img width="600" height="61" alt="Screenshot 2026-06-23 at 3 59 45 PM" src="https://github.com/user-attachments/assets/7aa6b8ad-cc70-4b94-9435-7270d2bebc98" />
<img width="595" height="67" alt="Screenshot 2026-06-23 at 3 59 54 PM" src="https://github.com/user-attachments/assets/fcc20ef4-4bf5-4203-8ee7-8cb12c2e8171" />
<img width="595" height="63" alt="Screenshot 2026-06-23 at 4 00 05 PM" src="https://github.com/user-attachments/assets/a4eef5b4-831d-4df8-83ef-83da998248d2" />
<img width="599" height="114" alt="Screenshot 2026-06-23 at 4 00 16 PM" src="https://github.com/user-attachments/assets/c24b8086-65b9-4d6f-94b4-ce6ad9200b28" />
<img width="601" height="92" alt="Screenshot 2026-06-23 at 4 00 33 PM" src="https://github.com/user-attachments/assets/ae499d07-cb29-47cd-bd31-e397aea2b3c1" />

## Issues
Closes #60