### PR TITLE
Add OTEL Profile Provider -> Event/Telemetry Logging with Loki/Prometheus

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nasa/hermes/pkg/influxdb"
 	"github.com/nasa/hermes/pkg/infra"
 	"github.com/nasa/hermes/pkg/log"
+	hermesotel "github.com/nasa/hermes/pkg/otel"
 	"github.com/nasa/hermes/pkg/pb"
 	"github.com/nasa/hermes/pkg/rpc"
 	"github.com/nasa/hermes/pkg/timescaledb"
@@ -76,6 +77,12 @@ func main() {
 	err = timescaledb.Init()
 	if err != nil {
 		logger.Error("failed to initialize timescaledb", "err", err)
+		os.Exit(1)
+	}
+
+	err = hermesotel.Init()
+	if err != nil {
+		logger.Error("failed to initialize otel", "err", err)
 		os.Exit(1)
 	}
 

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -1,0 +1,1 @@
+package otel

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -1,1 +1,52 @@
 package otel
+
+import (
+	"context"
+
+	_ "embed"
+
+	"github.com/nasa/hermes/pkg/host"
+)
+
+var (
+	_ host.ProfileProvider[Params] = (*otelProvider)(nil)
+)
+
+//go:embed schema.json
+var schema string
+
+type Params struct {
+	Endpoint    string `json:"endpoint"`
+	ServiceName string `json:"serviceName"`
+	Events      bool   `json:"events"`
+	Telemetry   bool   `json:"telemetry"`
+}
+
+type otelProvider struct{}
+
+func (o *otelProvider) Default() Params {
+	return Params{
+		Endpoint:    "localhost:4317",
+		ServiceName: "hermes",
+		Events:      true,
+		Telemetry:   false,
+	}
+}
+
+func (o *otelProvider) Start(
+	ctx context.Context,
+	settings Params,
+	session host.ConnectSession,
+) error {
+	return nil
+}
+
+func Init() error {
+	_, err := host.RegisterProfileProviderWithUiSchema(
+		"OpenTelemetry",
+		&otelProvider{},
+		schema,
+		`{"ui:order": ["endpoint", "serviceName", "events", "telemetry"]}`,
+	)
+	return err
+}

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -2,10 +2,17 @@ package otel
 
 import (
 	"context"
+	"fmt"
 
 	_ "embed"
 
 	"github.com/nasa/hermes/pkg/host"
+	"github.com/nasa/hermes/pkg/pb"
+	"go.opentelemetry.io/contrib/bridges/otelslog"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	"go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
 
 var (
@@ -38,6 +45,51 @@ func (o *otelProvider) Start(
 	settings Params,
 	session host.ConnectSession,
 ) error {
+	session.Log().Info("connecting to OTEL collector", "endpoint", settings.Endpoint)
+
+	exporter, err := otlploggrpc.New(ctx,
+		otlploggrpc.WithEndpoint(settings.Endpoint),
+		otlploggrpc.WithInsecure(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create OTEL exporter: %w", err)
+	}
+	defer exporter.Shutdown(context.Background())
+
+	res, err := resource.New(ctx,
+		resource.WithAttributes(semconv.ServiceNameKey.String(settings.ServiceName)),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create OTEL resource: %w", err)
+	}
+
+	provider := log.NewLoggerProvider(
+		log.WithResource(res),
+		log.WithProcessor(log.NewBatchProcessor(exporter)),
+	)
+	defer provider.Shutdown(context.Background())
+
+	handler := otelslog.NewHandler("hermes",
+		otelslog.WithLoggerProvider(provider),
+	)
+
+	session.Started()
+
+	if settings.Events {
+		session.Log().Info("exporting events to OTEL collector")
+		host.Event.On(ctx, func(msg *pb.SourcedEvent) {
+			handler.Handle(context.Background(), msg.GetEvent().Record())
+		})
+	}
+
+	if settings.Telemetry {
+		session.Log().Info("exporting telemetry to OTEL collector")
+		host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
+			handler.Handle(context.Background(), msg.GetTelemetry().Record())
+		})
+	}
+
+	<-ctx.Done()
 	return nil
 }
 

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -39,7 +39,7 @@ func (o *otelProvider) Default() Params {
 		Endpoint:    "localhost:4317",
 		ServiceName: "hermes",
 		Events:      true,
-		Telemetry:   false,
+		Telemetry:   true,
 	}
 }
 

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -36,7 +36,7 @@ type otelProvider struct{}
 
 func (o *otelProvider) Default() Params {
 	return Params{
-		Endpoint:    "localhost:4317",
+		Endpoint:    "",
 		ServiceName: "hermes",
 		Events:      true,
 		Telemetry:   true,

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"context"
 	"fmt"
+	"time"
 
 	_ "embed"
 
@@ -10,7 +11,9 @@ import (
 	"github.com/nasa/hermes/pkg/pb"
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
@@ -47,15 +50,6 @@ func (o *otelProvider) Start(
 ) error {
 	session.Log().Info("connecting to OTEL collector", "endpoint", settings.Endpoint)
 
-	exporter, err := otlploggrpc.New(ctx,
-		otlploggrpc.WithEndpoint(settings.Endpoint),
-		otlploggrpc.WithInsecure(),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create OTEL exporter: %w", err)
-	}
-	defer exporter.Shutdown(context.Background())
-
 	res, err := resource.New(ctx,
 		resource.WithAttributes(semconv.ServiceNameKey.String(settings.ServiceName)),
 	)
@@ -63,20 +57,30 @@ func (o *otelProvider) Start(
 		return fmt.Errorf("failed to create OTEL resource: %w", err)
 	}
 
-	provider := log.NewLoggerProvider(
-		log.WithResource(res),
-		log.WithProcessor(log.NewBatchProcessor(exporter)),
-	)
-	defer provider.Shutdown(context.Background())
-
-	handler := otelslog.NewHandler("hermes",
-		otelslog.WithLoggerProvider(provider),
-	)
-
-	session.Started()
-
 	if settings.Events {
 		session.Log().Info("exporting events to OTEL collector")
+
+		logOpts := []otlploggrpc.Option{otlploggrpc.WithInsecure()}
+		if settings.Endpoint != "" {
+			logOpts = append(logOpts, otlploggrpc.WithEndpoint(settings.Endpoint))
+		}
+
+		logExporter, err := otlploggrpc.New(ctx, logOpts...)
+		if err != nil {
+			return fmt.Errorf("failed to create OTEL log exporter: %w", err)
+		}
+		defer logExporter.Shutdown(context.Background())
+
+		logProvider := log.NewLoggerProvider(
+			log.WithResource(res),
+			log.WithProcessor(log.NewBatchProcessor(logExporter)),
+		)
+		defer logProvider.Shutdown(context.Background())
+
+		handler := otelslog.NewHandler("hermes",
+			otelslog.WithLoggerProvider(logProvider),
+		)
+
 		host.Event.On(ctx, func(msg *pb.SourcedEvent) {
 			handler.Handle(context.Background(), msg.GetEvent().Record())
 		})
@@ -84,10 +88,57 @@ func (o *otelProvider) Start(
 
 	if settings.Telemetry {
 		session.Log().Info("exporting telemetry to OTEL collector")
+
+		metricOpts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithInsecure()}
+		if settings.Endpoint != "" {
+			metricOpts = append(metricOpts, otlpmetricgrpc.WithEndpoint(settings.Endpoint))
+		}
+
+		metricExporter, err := otlpmetricgrpc.New(ctx, metricOpts...)
+		if err != nil {
+			return fmt.Errorf("failed to create OTEL metric exporter: %w", err)
+		}
+		defer metricExporter.Shutdown(context.Background())
+
+		cache := make(chan []metricdata.Metrics, 64)
+
+		go func() {
+			ticker := time.NewTicker(1 * time.Second)
+			defer ticker.Stop()
+			var buf []metricdata.Metrics
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case chunk := <-cache:
+					buf = append(buf, chunk...)
+				case <-ticker.C:
+					if len(buf) == 0 {
+						continue
+					}
+					exportErr := metricExporter.Export(ctx, &metricdata.ResourceMetrics{
+						Resource: res,
+						ScopeMetrics: []metricdata.ScopeMetrics{{
+							Metrics: buf,
+						}},
+					})
+					if exportErr != nil {
+						session.Log().Error("failed to export telemetry metrics", "err", exportErr)
+					}
+					buf = nil
+				}
+			}
+		}()
+
 		host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
-			handler.Handle(context.Background(), msg.GetTelemetry().Record())
+			m := msg.GetTelemetry().AsOtelMetric([]metricdata.Metrics{})
+			if len(m) > 0 {
+				cache <- m
+			}
 		})
 	}
+
+	session.Started()
 
 	<-ctx.Done()
 	return nil

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -36,7 +36,7 @@ type otelProvider struct{}
 
 func (o *otelProvider) Default() Params {
 	return Params{
-		Endpoint:    "",
+		Endpoint:    "localhost:4317",
 		ServiceName: "hermes",
 		Events:      true,
 		Telemetry:   true,
@@ -48,6 +48,10 @@ func (o *otelProvider) Start(
 	settings Params,
 	session host.ConnectSession,
 ) error {
+	if !settings.Events && !settings.Telemetry {
+		return fmt.Errorf("at least one of events or telemetry must be enabled")
+	}
+
 	session.Log().Info("connecting to OTEL collector", "endpoint", settings.Endpoint)
 
 	res, err := resource.New(ctx,

--- a/pkg/otel/schema.json
+++ b/pkg/otel/schema.json
@@ -23,7 +23,7 @@
         "telemetry": {
             "type": "boolean",
             "title": "Export Telemetry",
-            "default": false,
+            "default": true,
             "description": "Export channelized telemetry as metrics (e.g. to Prometheus)"
         }
     },

--- a/pkg/otel/schema.json
+++ b/pkg/otel/schema.json
@@ -18,13 +18,13 @@
             "type": "boolean",
             "title": "Export Events",
             "default": true,
-            "description": "Export flight software events as log records"
+            "description": "Export flight software events as log records (e.g. to Loki)"
         },
         "telemetry": {
             "type": "boolean",
             "title": "Export Telemetry",
             "default": false,
-            "description": "Export channelized telemetry as log records"
+            "description": "Export channelized telemetry as metrics (e.g. to Prometheus)"
         }
     },
     "required": ["endpoint"]

--- a/pkg/otel/schema.json
+++ b/pkg/otel/schema.json
@@ -1,0 +1,31 @@
+{
+    "type": "object",
+    "description": "Exports Events and Telemetry as OpenTelemetry log records to an OTLP-compatible collector",
+    "properties": {
+        "endpoint": {
+            "type": "string",
+            "title": "Collector Endpoint",
+            "default": "localhost:4317",
+            "description": "OTLP gRPC collector endpoint (e.g. localhost:4317)"
+        },
+        "serviceName": {
+            "type": "string",
+            "title": "Service Name",
+            "default": "hermes",
+            "description": "Identifies this source in the collector"
+        },
+        "events": {
+            "type": "boolean",
+            "title": "Export Events",
+            "default": true,
+            "description": "Export flight software events as log records"
+        },
+        "telemetry": {
+            "type": "boolean",
+            "title": "Export Telemetry",
+            "default": false,
+            "description": "Export channelized telemetry as log records"
+        }
+    },
+    "required": ["endpoint"]
+}

--- a/pkg/otel/schema.json
+++ b/pkg/otel/schema.json
@@ -6,7 +6,7 @@
             "type": "string",
             "title": "Collector Endpoint",
             "default": "localhost:4317",
-            "description": "OTLP gRPC collector endpoint (e.g. localhost:4317)"
+            "description": "OTLP gRPC collector endpoint. Leave empty to use OTEL_EXPORTER_OTLP_ENDPOINT env var."
         },
         "serviceName": {
             "type": "string",

--- a/pkg/otel/schema.json
+++ b/pkg/otel/schema.json
@@ -27,5 +27,5 @@
             "description": "Export channelized telemetry as metrics (e.g. to Prometheus)"
         }
     },
-    "required": ["endpoint"]
+    "required": []
 }

--- a/pkg/pb/bus.pb.go
+++ b/pkg/pb/bus.pb.go
@@ -407,10 +407,6 @@ type SourcedEvent struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *SourcedEvent) GetTelemetry() {
-	panic("unimplemented")
-}
-
 func (x *SourcedEvent) Reset() {
 	*x = SourcedEvent{}
 	mi := &file_bus_proto_msgTypes[3]

--- a/pkg/pb/bus.pb.go
+++ b/pkg/pb/bus.pb.go
@@ -407,6 +407,10 @@ type SourcedEvent struct {
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *SourcedEvent) GetTelemetry() {
+	panic("unimplemented")
+}
+
 func (x *SourcedEvent) Reset() {
 	*x = SourcedEvent{}
 	mi := &file_bus_proto_msgTypes[3]


### PR DESCRIPTION
## Description
Creates a new Profile Provider for the `hermes` extension allowing the user to configure OpenTelemetry from the GUI. The user enters a Collector Endpoint and Service Name, and chooses to Export Events (as log records, which could be sent to Loki) and/or Export Telemetry (sent as metrics, which could be sent to Prometheus).

This Provider follows a similar structure to the previous providers, implementing a `schema.json` for the aforementioned fields to collect them as a form, and a `otel.go` which registers the provider and implements `Start`.
## Implementation
The functions other than `Start()` are boilerplate; `Default()` provides fallback values, and `Init()` registers the provider with the given UI schema. `Start()` conditionally manages event/telemetry export depending on the user preference (selected in the GUI). If the user does not specify a Collector Endpoint, the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is used instead.

Events use a Log `Exporter` and `LoggerProvider` using a `BatchProcessor`, and on a new `SourcedEvent` the event is converted to a record and passed to the logger.

Telemetry uses a Metric `Exporter` and a goroutine which caches telemetry readings in batches and exports them every second; on a new `SourcedTelemetry`, the reading is sent to the cache. The `Exporter` is used directly without `MeterProvider` because the telemetry data already has timestamps and values.

> [!NOTE]
> The provider returns an error on "play" if the user failed to select at least one of Events/Telemetry. 
## Screenshots
<img width="224" height="453" alt="Screenshot 2026-07-07 at 1 19 00 PM" src="https://github.com/user-attachments/assets/24b49c0b-c090-44da-99f1-b4cfe10726c2" />
<img width="257" height="39" alt="Screenshot 2026-07-07 at 1 19 23 PM" src="https://github.com/user-attachments/assets/9840373c-1e74-4720-a97d-1dc3707672d0" />
<img width="455" height="111" alt="Screenshot 2026-07-07 at 1 19 41 PM" src="https://github.com/user-attachments/assets/b18df0b8-e608-44db-a85e-710106b0aa32" />
<img width="783" height="707" alt="Screenshot 2026-07-07 at 1 20 12 PM" src="https://github.com/user-attachments/assets/f6d36319-328e-4af4-900d-0dfa2928ac11" />
<img width="786" height="669" alt="Screenshot 2026-07-07 at 1 21 45 PM" src="https://github.com/user-attachments/assets/17816ba8-68ed-4808-bc7a-7d72a0c09035" />

## Issues
Closes #79 