### PR TITLE
Add events/telemetry logging toggles to TimescaleDB and InfluxDB providers

### DIFF
--- a/pkg/influxdb/influxdb.go
+++ b/pkg/influxdb/influxdb.go
@@ -21,6 +21,8 @@ var (
 //go:embed schema.json
 var schema string
 
+var uiSchema = `{"ui:order": ["url", "token", "orgId", "bucket", "defaultTags", "ert", "events", "telemetry"]}`
+
 type Params struct {
 	Url string `json:"url"`
 
@@ -29,10 +31,24 @@ type Params struct {
 		Value string `json:"value"`
 	} `json:"defaultTags"`
 
-	Token  string `json:"token"`
-	OrgId  string `json:"orgId"`
-	Bucket string `json:"bucket"`
-	Ert    bool   `json:"ert"`
+	Token     string `json:"token"`
+	OrgId     string `json:"orgId"`
+	Bucket    string `json:"bucket"`
+	Ert       bool   `json:"ert"`
+	Events    *bool  `json:"events,omitempty"`
+	Telemetry *bool  `json:"telemetry,omitempty"`
+}
+
+// EventsEnabled reports whether events should be pushed. Profiles saved
+// before this option existed have no key and must stay enabled.
+func (p Params) EventsEnabled() bool {
+	return p.Events == nil || *p.Events
+}
+
+// TelemetryEnabled reports whether telemetry should be pushed. Profiles
+// saved before this option existed have no key and must stay enabled.
+func (p Params) TelemetryEnabled() bool {
+	return p.Telemetry == nil || *p.Telemetry
 }
 
 type influxDbProvider struct{}
@@ -114,35 +130,43 @@ func (i *influxDbProvider) Start(
 		}
 	}()
 
-	session.Log().Info("creating event bus listener to push to influxdb")
-	host.Event.On(ctx, func(msg *pb.SourcedEvent) {
-		mtr, err := SourcedEventAsMetric(msg)
+	if settings.EventsEnabled() {
+		session.Log().Info("creating event bus listener to push to influxdb")
+		host.Event.On(ctx, func(msg *pb.SourcedEvent) {
+			mtr, err := SourcedEventAsMetric(msg)
 
-		if settings.Ert {
-			mtr.AddField("ert", time.Now().UnixMilli())
-		}
+			if settings.Ert {
+				mtr.AddField("ert", time.Now().UnixMilli())
+			}
 
-		if err != nil {
-			session.Log().Warn("failed to convert event to influxdb metric", "err", err)
-		} else {
-			writeAPI.WritePoint(metricAsPoint(mtr))
-		}
-	})
+			if err != nil {
+				session.Log().Warn("failed to convert event to influxdb metric", "err", err)
+			} else {
+				writeAPI.WritePoint(metricAsPoint(mtr))
+			}
+		})
+	} else {
+		session.Log().Info("event logging to influxdb is disabled by profile settings")
+	}
 
-	session.Log().Info("creating telemetry bus listener to push to influxdb")
-	host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
-		mtr, err := SourcedTelemetryAsMetric(msg)
+	if settings.TelemetryEnabled() {
+		session.Log().Info("creating telemetry bus listener to push to influxdb")
+		host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
+			mtr, err := SourcedTelemetryAsMetric(msg)
 
-		if settings.Ert {
-			mtr.AddField("ert", time.Now().UnixMilli())
-		}
+			if settings.Ert {
+				mtr.AddField("ert", time.Now().UnixMilli())
+			}
 
-		if err != nil {
-			session.Log().Warn("failed to convert telemetry to influxdb metric", "err", err)
-		} else {
-			writeAPI.WritePoint(metricAsPoint(mtr))
-		}
-	})
+			if err != nil {
+				session.Log().Warn("failed to convert telemetry to influxdb metric", "err", err)
+			} else {
+				writeAPI.WritePoint(metricAsPoint(mtr))
+			}
+		})
+	} else {
+		session.Log().Info("telemetry logging to influxdb is disabled by profile settings")
+	}
 
 	wg.Wait()
 	return nil
@@ -153,7 +177,7 @@ func Init() error {
 		"InfluxDB",
 		&influxDbProvider{},
 		schema,
-		`{"ui:order": ["url", "token", "orgId", "bucket", "defaultTags", "ert"]}`,
+		uiSchema,
 	)
 
 	if err != nil {

--- a/pkg/influxdb/params_test.go
+++ b/pkg/influxdb/params_test.go
@@ -1,0 +1,184 @@
+package influxdb
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParamsWithoutTogglesKeepsBothEnabled(t *testing.T) {
+	// Settings saved before the toggles existed must keep logging both.
+	var p Params
+	if err := json.Unmarshal([]byte(`{"url":"http://localhost:8086","bucket":"tlm"}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.EventsEnabled() {
+		t.Error("events should be enabled when the key is absent")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("telemetry should be enabled when the key is absent")
+	}
+}
+
+func TestParamsCanDisableEventsOnly(t *testing.T) {
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":false,"telemetry":true}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if p.EventsEnabled() {
+		t.Error("events should be disabled when set to false")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("telemetry should stay enabled when set to true")
+	}
+}
+
+func TestParamsCanDisableTelemetryOnly(t *testing.T) {
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":true,"telemetry":false}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.EventsEnabled() {
+		t.Error("events should stay enabled when set to true")
+	}
+	if p.TelemetryEnabled() {
+		t.Error("telemetry should be disabled when set to false")
+	}
+}
+
+func TestNilTogglesAreOmittedFromMarshaledSettings(t *testing.T) {
+	// The frontend renders settings JSON straight into the form. A literal
+	// null bypasses the schema's default:true and draws an unchecked box
+	// while the backend keeps logging — nil pointers must serialize as
+	// absent keys, not null.
+	b, err := json.Marshal((&influxDbProvider{}).Default())
+	if err != nil {
+		t.Fatalf("failed to marshal default params: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("failed to decode marshaled params: %v", err)
+	}
+
+	if v, ok := m["events"]; ok {
+		t.Errorf("unset events should be omitted from settings, got %s", v)
+	}
+	if v, ok := m["telemetry"]; ok {
+		t.Errorf("unset telemetry should be omitted from settings, got %s", v)
+	}
+}
+
+func TestSchemaAndUiOrderStayInSync(t *testing.T) {
+	// RJSF replaces the entire form with a config-error box when ui:order
+	// misses a property, so schema.json and the ui:order list must never
+	// drift apart.
+	var s struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(schema), &s); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+
+	var u struct {
+		Order []string `json:"ui:order"`
+	}
+	if err := json.Unmarshal([]byte(uiSchema), &u); err != nil {
+		t.Fatalf("uiSchema is not valid JSON: %v", err)
+	}
+
+	ordered := map[string]bool{}
+	for _, name := range u.Order {
+		ordered[name] = true
+		if _, ok := s.Properties[name]; !ok {
+			t.Errorf("ui:order lists %q which is not a schema property", name)
+		}
+	}
+	for name := range s.Properties {
+		if !ordered[name] {
+			t.Errorf("schema property %q is missing from ui:order", name)
+		}
+	}
+}
+
+func TestTogglesAreNotRequired(t *testing.T) {
+	// Profiles saved before the toggles existed have no keys; requiring
+	// them would make every legacy profile fail form validation.
+	var s struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(schema), &s); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+
+	for _, name := range s.Required {
+		if name == "events" || name == "telemetry" {
+			t.Errorf("%q must not be a required property", name)
+		}
+	}
+}
+
+func TestExplicitNullMeansEnabled(t *testing.T) {
+	// A literal null must reset a previously-disabled toggle back to the
+	// enabled default — this tri-state contract (null == absent == enabled)
+	// is what makes old settings round-trips safe.
+	off := false
+	p := Params{Events: &off, Telemetry: &off}
+	if err := json.Unmarshal([]byte(`{"events":null,"telemetry":null}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.EventsEnabled() {
+		t.Error("null events should mean enabled")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("null telemetry should mean enabled")
+	}
+}
+
+func TestBothTogglesCanBeDisabled(t *testing.T) {
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":false,"telemetry":false}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if p.EventsEnabled() || p.TelemetryEnabled() {
+		t.Error("both toggles should be disabled when both are false")
+	}
+}
+
+func TestExplicitTrueSurvivesMarshal(t *testing.T) {
+	// omitempty must only drop nil pointers — an explicit true has to
+	// round-trip as a real boolean, not vanish.
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":true,"telemetry":true}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("failed to marshal params: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("failed to decode marshaled params: %v", err)
+	}
+
+	if string(m["events"]) != "true" || string(m["telemetry"]) != "true" {
+		t.Errorf("explicit true should marshal as true, got events=%s telemetry=%s", m["events"], m["telemetry"])
+	}
+}
+
+func TestDefaultEnablesBothToggles(t *testing.T) {
+	p := (&influxDbProvider{}).Default()
+
+	if !p.EventsEnabled() {
+		t.Error("default profile should have events enabled")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("default profile should have telemetry enabled")
+	}
+}

--- a/pkg/influxdb/schema.json
+++ b/pkg/influxdb/schema.json
@@ -45,6 +45,18 @@
             "title": "ERT",
             "default": true,
             "description": "Attach Earth-Return-Time as an additional field to every point"
+        },
+        "events": {
+            "type": "boolean",
+            "title": "Log Events",
+            "default": true,
+            "description": "Push events (EVRs) to this database."
+        },
+        "telemetry": {
+            "type": "boolean",
+            "title": "Log Telemetry",
+            "default": true,
+            "description": "Push telemetry channels to this database."
         }
     },
     "required": [

--- a/pkg/timescaledb/params_test.go
+++ b/pkg/timescaledb/params_test.go
@@ -1,0 +1,184 @@
+package timescaledb
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParamsWithoutTogglesKeepsBothEnabled(t *testing.T) {
+	// Settings saved before the toggles existed must keep logging both.
+	var p Params
+	if err := json.Unmarshal([]byte(`{"host":"localhost:5432","database":"tlm"}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.EventsEnabled() {
+		t.Error("events should be enabled when the key is absent")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("telemetry should be enabled when the key is absent")
+	}
+}
+
+func TestParamsCanDisableEventsOnly(t *testing.T) {
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":false,"telemetry":true}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if p.EventsEnabled() {
+		t.Error("events should be disabled when set to false")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("telemetry should stay enabled when set to true")
+	}
+}
+
+func TestParamsCanDisableTelemetryOnly(t *testing.T) {
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":true,"telemetry":false}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.EventsEnabled() {
+		t.Error("events should stay enabled when set to true")
+	}
+	if p.TelemetryEnabled() {
+		t.Error("telemetry should be disabled when set to false")
+	}
+}
+
+func TestNilTogglesAreOmittedFromMarshaledSettings(t *testing.T) {
+	// The frontend renders settings JSON straight into the form. A literal
+	// null bypasses the schema's default:true and draws an unchecked box
+	// while the backend keeps logging — nil pointers must serialize as
+	// absent keys, not null.
+	b, err := json.Marshal((&timescaleDbProvider{}).Default())
+	if err != nil {
+		t.Fatalf("failed to marshal default params: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("failed to decode marshaled params: %v", err)
+	}
+
+	if v, ok := m["events"]; ok {
+		t.Errorf("unset events should be omitted from settings, got %s", v)
+	}
+	if v, ok := m["telemetry"]; ok {
+		t.Errorf("unset telemetry should be omitted from settings, got %s", v)
+	}
+}
+
+func TestSchemaAndUiOrderStayInSync(t *testing.T) {
+	// RJSF replaces the entire form with a config-error box when ui:order
+	// misses a property, so schema.json and the ui:order list must never
+	// drift apart.
+	var s struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(schema), &s); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+
+	var u struct {
+		Order []string `json:"ui:order"`
+	}
+	if err := json.Unmarshal([]byte(uiSchema), &u); err != nil {
+		t.Fatalf("uiSchema is not valid JSON: %v", err)
+	}
+
+	ordered := map[string]bool{}
+	for _, name := range u.Order {
+		ordered[name] = true
+		if _, ok := s.Properties[name]; !ok {
+			t.Errorf("ui:order lists %q which is not a schema property", name)
+		}
+	}
+	for name := range s.Properties {
+		if !ordered[name] {
+			t.Errorf("schema property %q is missing from ui:order", name)
+		}
+	}
+}
+
+func TestTogglesAreNotRequired(t *testing.T) {
+	// Profiles saved before the toggles existed have no keys; requiring
+	// them would make every legacy profile fail form validation.
+	var s struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(schema), &s); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+
+	for _, name := range s.Required {
+		if name == "events" || name == "telemetry" {
+			t.Errorf("%q must not be a required property", name)
+		}
+	}
+}
+
+func TestExplicitNullMeansEnabled(t *testing.T) {
+	// A literal null must reset a previously-disabled toggle back to the
+	// enabled default — this tri-state contract (null == absent == enabled)
+	// is what makes old settings round-trips safe.
+	off := false
+	p := Params{Events: &off, Telemetry: &off}
+	if err := json.Unmarshal([]byte(`{"events":null,"telemetry":null}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.EventsEnabled() {
+		t.Error("null events should mean enabled")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("null telemetry should mean enabled")
+	}
+}
+
+func TestBothTogglesCanBeDisabled(t *testing.T) {
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":false,"telemetry":false}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if p.EventsEnabled() || p.TelemetryEnabled() {
+		t.Error("both toggles should be disabled when both are false")
+	}
+}
+
+func TestExplicitTrueSurvivesMarshal(t *testing.T) {
+	// omitempty must only drop nil pointers — an explicit true has to
+	// round-trip as a real boolean, not vanish.
+	var p Params
+	if err := json.Unmarshal([]byte(`{"events":true,"telemetry":true}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("failed to marshal params: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("failed to decode marshaled params: %v", err)
+	}
+
+	if string(m["events"]) != "true" || string(m["telemetry"]) != "true" {
+		t.Errorf("explicit true should marshal as true, got events=%s telemetry=%s", m["events"], m["telemetry"])
+	}
+}
+
+func TestDefaultEnablesBothToggles(t *testing.T) {
+	p := (&timescaleDbProvider{}).Default()
+
+	if !p.EventsEnabled() {
+		t.Error("default profile should have events enabled")
+	}
+	if !p.TelemetryEnabled() {
+		t.Error("default profile should have telemetry enabled")
+	}
+}

--- a/pkg/timescaledb/schema.json
+++ b/pkg/timescaledb/schema.json
@@ -22,6 +22,18 @@
             "type": "string",
             "title": "Database",
             "description": "Database name where telemetry and events will be stored."
+        },
+        "events": {
+            "type": "boolean",
+            "title": "Log Events",
+            "default": true,
+            "description": "Push events (EVRs) to this database."
+        },
+        "telemetry": {
+            "type": "boolean",
+            "title": "Log Telemetry",
+            "default": true,
+            "description": "Push telemetry channels to this database."
         }
     },
     "required": [

--- a/pkg/timescaledb/timescaledb.go
+++ b/pkg/timescaledb/timescaledb.go
@@ -20,14 +20,30 @@ var (
 //go:embed schema.json
 var schema string
 
+var uiSchema = `{"ui:order": ["host", "user", "password", "database", "events", "telemetry"]}`
+
 //go:embed schema.sql
 var schemaSql string
 
 type Params struct {
-	Host     string `json:"host"`
-	User     string `json:"user"`
-	Password string `json:"password"`
-	Database string `json:"database"`
+	Host      string `json:"host"`
+	User      string `json:"user"`
+	Password  string `json:"password"`
+	Database  string `json:"database"`
+	Events    *bool  `json:"events,omitempty"`
+	Telemetry *bool  `json:"telemetry,omitempty"`
+}
+
+// EventsEnabled reports whether events should be pushed. Profiles saved
+// before this option existed have no key and must stay enabled.
+func (p Params) EventsEnabled() bool {
+	return p.Events == nil || *p.Events
+}
+
+// TelemetryEnabled reports whether telemetry should be pushed. Profiles
+// saved before this option existed have no key and must stay enabled.
+func (p Params) TelemetryEnabled() bool {
+	return p.Telemetry == nil || *p.Telemetry
 }
 
 type timescaleDbProvider struct{}
@@ -71,19 +87,27 @@ func (t *timescaleDbProvider) Start(
 
 	session.Started()
 
-	session.Log().Info("creating event bus listener to push to timescaledb")
-	host.Event.On(ctx, func(msg *pb.SourcedEvent) {
-		if err := InsertEvent(ctx, db, msg); err != nil {
-			session.Log().Error("failed to insert event to timescaledb", "err", err)
-		}
-	})
+	if settings.EventsEnabled() {
+		session.Log().Info("creating event bus listener to push to timescaledb")
+		host.Event.On(ctx, func(msg *pb.SourcedEvent) {
+			if err := InsertEvent(ctx, db, msg); err != nil {
+				session.Log().Error("failed to insert event to timescaledb", "err", err)
+			}
+		})
+	} else {
+		session.Log().Info("event logging to timescaledb is disabled by profile settings")
+	}
 
-	session.Log().Info("creating telemetry bus listener to push to timescaledb")
-	host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
-		if err := InsertTelemetry(ctx, db, msg); err != nil {
-			session.Log().Error("failed to insert telemetry to timescaledb", "err", err)
-		}
-	})
+	if settings.TelemetryEnabled() {
+		session.Log().Info("creating telemetry bus listener to push to timescaledb")
+		host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
+			if err := InsertTelemetry(ctx, db, msg); err != nil {
+				session.Log().Error("failed to insert telemetry to timescaledb", "err", err)
+			}
+		})
+	} else {
+		session.Log().Info("telemetry logging to timescaledb is disabled by profile settings")
+	}
 
 	<-ctx.Done()
 	return nil
@@ -94,7 +118,7 @@ func Init() error {
 		"TimescaleDB",
 		&timescaleDbProvider{},
 		schema,
-		`{"ui:order": ["host", "user", "password", "database"]}`,
+		uiSchema,
 	)
 
 	if err != nil {


### PR DESCRIPTION
## What this does

Adds two checkboxes — **Log Events** and **Log Telemetry** — to the TimescaleDB and InfluxDB connection settings, so you can pick which kinds of data get sent to each database.

## Why

Today every provider receives both events and telemetry whether you want them there or not. This lets you send, for example, telemetry to one database and events somewhere else — the choice raised in #85.

## What changed

- Two new checkboxes on both the TimescaleDB and InfluxDB settings forms, both on by default.
- Turning one off stops that kind of data from being written to that database.
- Existing saved connections keep working exactly as before — both stay on until you change them.
- Added tests covering the on/off combinations and the "old connection with no keys set" case, plus a guard that each provider's schema and field ordering stay in sync.

## How to see it

Open the Connections panel, add or edit a TimescaleDB or InfluxDB connection, and the two new checkboxes appear at the bottom of the form.

Closes #85