### PR TITLE
Allow users to select events/telemetry output for Timescale/Influx

### DIFF
--- a/pkg/influxdb/influxdb.go
+++ b/pkg/influxdb/influxdb.go
@@ -29,10 +29,12 @@ type Params struct {
 		Value string `json:"value"`
 	} `json:"defaultTags"`
 
-	Token  string `json:"token"`
-	OrgId  string `json:"orgId"`
-	Bucket string `json:"bucket"`
-	Ert    bool   `json:"ert"`
+	Token     string `json:"token"`
+	OrgId     string `json:"orgId"`
+	Bucket    string `json:"bucket"`
+	Ert       bool   `json:"ert"`
+	Events    bool   `json:"events"`
+	Telemetry bool   `json:"telemetry"`
 }
 
 type influxDbProvider struct{}
@@ -40,7 +42,9 @@ type influxDbProvider struct{}
 // Default implements host.ProfileProvider.
 func (i *influxDbProvider) Default() Params {
 	return Params{
-		Ert: true,
+		Ert:       true,
+		Events:    true,
+		Telemetry: true,
 	}
 }
 
@@ -114,35 +118,39 @@ func (i *influxDbProvider) Start(
 		}
 	}()
 
-	session.Log().Info("creating event bus listener to push to influxdb")
-	host.Event.On(ctx, func(msg *pb.SourcedEvent) {
-		mtr, err := SourcedEventAsMetric(msg)
+	if settings.Events {
+		session.Log().Info("creating event bus listener to push to influxdb")
+		host.Event.On(ctx, func(msg *pb.SourcedEvent) {
+			mtr, err := SourcedEventAsMetric(msg)
 
-		if settings.Ert {
-			mtr.AddField("ert", time.Now().UnixMilli())
-		}
+			if settings.Ert {
+				mtr.AddField("ert", time.Now().UnixMilli())
+			}
 
-		if err != nil {
-			session.Log().Warn("failed to convert event to influxdb metric", "err", err)
-		} else {
-			writeAPI.WritePoint(metricAsPoint(mtr))
-		}
-	})
+			if err != nil {
+				session.Log().Warn("failed to convert event to influxdb metric", "err", err)
+			} else {
+				writeAPI.WritePoint(metricAsPoint(mtr))
+			}
+		})
+	}
 
-	session.Log().Info("creating telemetry bus listener to push to influxdb")
-	host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
-		mtr, err := SourcedTelemetryAsMetric(msg)
+	if settings.Telemetry {
+		session.Log().Info("creating telemetry bus listener to push to influxdb")
+		host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
+			mtr, err := SourcedTelemetryAsMetric(msg)
 
-		if settings.Ert {
-			mtr.AddField("ert", time.Now().UnixMilli())
-		}
+			if settings.Ert {
+				mtr.AddField("ert", time.Now().UnixMilli())
+			}
 
-		if err != nil {
-			session.Log().Warn("failed to convert telemetry to influxdb metric", "err", err)
-		} else {
-			writeAPI.WritePoint(metricAsPoint(mtr))
-		}
-	})
+			if err != nil {
+				session.Log().Warn("failed to convert telemetry to influxdb metric", "err", err)
+			} else {
+				writeAPI.WritePoint(metricAsPoint(mtr))
+			}
+		})
+	}
 
 	wg.Wait()
 	return nil
@@ -153,7 +161,7 @@ func Init() error {
 		"InfluxDB",
 		&influxDbProvider{},
 		schema,
-		`{"ui:order": ["url", "token", "orgId", "bucket", "defaultTags", "ert"]}`,
+		`{"ui:order": ["url", "token", "orgId", "bucket", "defaultTags", "ert", "events", "telemetry"]}`,
 	)
 
 	if err != nil {

--- a/pkg/influxdb/schema.json
+++ b/pkg/influxdb/schema.json
@@ -45,6 +45,18 @@
             "title": "ERT",
             "default": true,
             "description": "Attach Earth-Return-Time as an additional field to every point"
+        },
+        "events": {
+            "type": "boolean",
+            "title": "Export Events",
+            "default": true,
+            "description": "Export flight software events to InfluxDB"
+        },
+        "telemetry": {
+            "type": "boolean",
+            "title": "Export Telemetry",
+            "default": true,
+            "description": "Export channelized telemetry to InfluxDB"
         }
     },
     "required": [

--- a/pkg/timescaledb/schema.json
+++ b/pkg/timescaledb/schema.json
@@ -22,6 +22,18 @@
             "type": "string",
             "title": "Database",
             "description": "Database name where telemetry and events will be stored."
+        },
+        "events": {
+            "type": "boolean",
+            "title": "Export Events",
+            "default": true,
+            "description": "Export flight software events to TimescaleDB"
+        },
+        "telemetry": {
+            "type": "boolean",
+            "title": "Export Telemetry",
+            "default": true,
+            "description": "Export channelized telemetry to TimescaleDB"
         }
     },
     "required": [

--- a/pkg/timescaledb/timescaledb.go
+++ b/pkg/timescaledb/timescaledb.go
@@ -24,10 +24,12 @@ var schema string
 var schemaSql string
 
 type Params struct {
-	Host     string `json:"host"`
-	User     string `json:"user"`
-	Password string `json:"password"`
-	Database string `json:"database"`
+	Host      string `json:"host"`
+	User      string `json:"user"`
+	Password  string `json:"password"`
+	Database  string `json:"database"`
+	Events    bool   `json:"events"`
+	Telemetry bool   `json:"telemetry"`
 }
 
 type timescaleDbProvider struct{}
@@ -35,7 +37,9 @@ type timescaleDbProvider struct{}
 // Default implements host.ProfileProvider.
 func (i *timescaleDbProvider) Default() Params {
 	return Params{
-		Host: "localhost:5432",
+		Host:      "localhost:5432",
+		Events:    true,
+		Telemetry: true,
 	}
 }
 
@@ -71,19 +75,23 @@ func (t *timescaleDbProvider) Start(
 
 	session.Started()
 
-	session.Log().Info("creating event bus listener to push to timescaledb")
-	host.Event.On(ctx, func(msg *pb.SourcedEvent) {
-		if err := InsertEvent(ctx, db, msg); err != nil {
-			session.Log().Error("failed to insert event to timescaledb", "err", err)
-		}
-	})
+	if settings.Events {
+		session.Log().Info("creating event bus listener to push to timescaledb")
+		host.Event.On(ctx, func(msg *pb.SourcedEvent) {
+			if err := InsertEvent(ctx, db, msg); err != nil {
+				session.Log().Error("failed to insert event to timescaledb", "err", err)
+			}
+		})
+	}
 
-	session.Log().Info("creating telemetry bus listener to push to timescaledb")
-	host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
-		if err := InsertTelemetry(ctx, db, msg); err != nil {
-			session.Log().Error("failed to insert telemetry to timescaledb", "err", err)
-		}
-	})
+	if settings.Telemetry {
+		session.Log().Info("creating telemetry bus listener to push to timescaledb")
+		host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
+			if err := InsertTelemetry(ctx, db, msg); err != nil {
+				session.Log().Error("failed to insert telemetry to timescaledb", "err", err)
+			}
+		})
+	}
 
 	<-ctx.Done()
 	return nil
@@ -94,7 +102,7 @@ func Init() error {
 		"TimescaleDB",
 		&timescaleDbProvider{},
 		schema,
-		`{"ui:order": ["host", "user", "password", "database"]}`,
+		`{"ui:order": ["host", "user", "password", "database", "events", "telemetry"]}`,
 	)
 
 	if err != nil {


### PR DESCRIPTION
## Description
Add checkboxes to the extension GUI to allow the user to opt-_out_ of exporting a type of data (telemetry, events) to the database in the provider. This follows from the work in #86 which outlines this process.
## Changes
Updated corresponding `schema.json` and `[provider].go` files to include new form parameters, and included conditional guards to apply/prevent event/telemetry logging as needed.
## Screenshots
<div align="center">
<table>
<tr>
<td><img width="300" alt="TimescaleDB settings" src="https://github.com/user-attachments/assets/9e1f35a1-65be-477a-9b15-8d0befa9d20f" /></td>
<td><img width="300" alt="InfluxDB settings" src="https://github.com/user-attachments/assets/6b5a9cec-fae5-409f-baa5-eaa48a2d8207" /></td>
</tr>
<tr>
<td align="center"><em>TimescaleDB</em></td>
<td align="center"><em>InfluxDB</em></td>
</tr>
</table>
</div>

## Issues
Closes #85