### PR TITLE
Fix the File Downlinks dashboard on the TimescaleDB stack

### DIFF
--- a/pkg/timescaledb/convert.go
+++ b/pkg/timescaledb/convert.go
@@ -20,6 +20,8 @@ const (
 		VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
 	insertTelemetrySQL = `INSERT INTO telemetry (time, telemetryDefId, timeSclk, source, labels, key, valueType, integral, floating, boolval, string, bytes, ert)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) ON CONFLICT DO NOTHING`
+	insertDownlinkSQL = `INSERT INTO fileDownlinks (uid, timeStart, timeEnd, status, source, sourcePath, destinationPath, filePath, fileSize, missingChunks, missingBytes, duplicateChunks, duplicateBytes, metadata, ert)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) ON CONFLICT DO NOTHING`
 )
 
 func valuesToAnys(values []*pb.Value) ([]any, error) {
@@ -101,6 +103,64 @@ func InsertTelemetry(ctx context.Context, db *sql.DB, msg *pb.SourcedTelemetry) 
 	}
 
 	return tx.Commit()
+}
+
+func chunkBytes(chunks []*pb.FileDownlinkChunk) int64 {
+	total := int64(0)
+	for _, chunk := range chunks {
+		total += int64(chunk.GetSize())
+	}
+	return total
+}
+
+// downlinkArgs builds the insertDownlinkSQL parameters (all but ert) from a
+// finished downlink. Status is stored as the enum name so dashboards can map
+// the same strings the OTEL log path exported via FileDownlink.Record().
+func downlinkArgs(msg *pb.FileDownlink) ([]any, error) {
+	missingChunks, err := json.Marshal(msg.GetMissingChunks())
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal missing chunks: %w", err)
+	}
+
+	duplicateChunks, err := json.Marshal(msg.GetDuplicateChunks())
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal duplicate chunks: %w", err)
+	}
+
+	metadata, err := json.Marshal(msg.GetMetadata())
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	return []any{
+		msg.GetUid(),
+		msg.GetTimeStart().AsTime(),
+		msg.GetTimeEnd().AsTime(),
+		msg.GetStatus().String(),
+		msg.GetSource(),
+		msg.GetSourcePath(),
+		msg.GetDestinationPath(),
+		msg.GetFilePath(),
+		int64(msg.GetSize()),
+		string(missingChunks),
+		chunkBytes(msg.GetMissingChunks()),
+		string(duplicateChunks),
+		chunkBytes(msg.GetDuplicateChunks()),
+		string(metadata),
+	}, nil
+}
+
+func InsertDownlink(ctx context.Context, db *sql.DB, msg *pb.FileDownlink) error {
+	args, err := downlinkArgs(msg)
+	if err != nil {
+		return fmt.Errorf("failed to convert file downlink: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, insertDownlinkSQL, append(args, stdtime.Now())...); err != nil {
+		return fmt.Errorf("failed to insert file downlink: %w", err)
+	}
+
+	return nil
 }
 
 func insertValue(ctx context.Context, tx *sql.Tx, time *pb.Time, telemetryDefId int32, source string, labels string, path string, value *pb.Value) error {

--- a/pkg/timescaledb/downlink_test.go
+++ b/pkg/timescaledb/downlink_test.go
@@ -1,0 +1,220 @@
+package timescaledb
+
+import (
+	"encoding/json"
+	"testing"
+	stdtime "time"
+
+	"github.com/nasa/hermes/pkg/pb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestParamsWithoutDownlinksToggleKeepsItEnabled(t *testing.T) {
+	// Settings saved before the toggle existed must start logging downlinks
+	// automatically — that is the whole point of issue #110.
+	var p Params
+	if err := json.Unmarshal([]byte(`{"host":"localhost:5432","database":"tlm"}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.DownlinksEnabled() {
+		t.Error("downlinks should be enabled when the key is absent")
+	}
+}
+
+func TestParamsCanDisableDownlinksOnly(t *testing.T) {
+	var p Params
+	if err := json.Unmarshal([]byte(`{"downlinks":false}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if p.DownlinksEnabled() {
+		t.Error("downlinks should be disabled when set to false")
+	}
+	if !p.EventsEnabled() || !p.TelemetryEnabled() {
+		t.Error("events and telemetry should stay enabled when only downlinks is set")
+	}
+}
+
+func TestExplicitNullDownlinksMeansEnabled(t *testing.T) {
+	off := false
+	p := Params{Downlinks: &off}
+	if err := json.Unmarshal([]byte(`{"downlinks":null}`), &p); err != nil {
+		t.Fatalf("failed to decode settings: %v", err)
+	}
+
+	if !p.DownlinksEnabled() {
+		t.Error("null downlinks should mean enabled")
+	}
+}
+
+func TestDefaultEnablesDownlinks(t *testing.T) {
+	if !(&timescaleDbProvider{}).Default().DownlinksEnabled() {
+		t.Error("default profile should have downlinks enabled")
+	}
+}
+
+func TestNilDownlinksToggleIsOmittedFromMarshaledSettings(t *testing.T) {
+	b, err := json.Marshal((&timescaleDbProvider{}).Default())
+	if err != nil {
+		t.Fatalf("failed to marshal default params: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("failed to decode marshaled params: %v", err)
+	}
+
+	if v, ok := m["downlinks"]; ok {
+		t.Errorf("unset downlinks should be omitted from settings, got %s", v)
+	}
+}
+
+func TestDownlinksToggleIsNotRequired(t *testing.T) {
+	var s struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(schema), &s); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+
+	for _, name := range s.Required {
+		if name == "downlinks" {
+			t.Error("downlinks must not be a required property")
+		}
+	}
+}
+
+func TestSchemaOffersDownlinksToggleDefaultingOn(t *testing.T) {
+	var s struct {
+		Properties map[string]struct {
+			Type    string          `json:"type"`
+			Default json.RawMessage `json:"default"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(schema), &s); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+
+	prop, ok := s.Properties["downlinks"]
+	if !ok {
+		t.Fatal("schema.json should offer a downlinks property")
+	}
+	if prop.Type != "boolean" {
+		t.Errorf("downlinks should be a boolean property, got %q", prop.Type)
+	}
+	if string(prop.Default) != "true" {
+		t.Errorf("downlinks should default to true in the form, got %s", prop.Default)
+	}
+}
+
+func TestDownlinkArgsMapsAllFields(t *testing.T) {
+	start := stdtime.Date(2026, 7, 16, 10, 0, 0, 0, stdtime.UTC)
+	end := start.Add(90 * stdtime.Second)
+	msg := &pb.FileDownlink{
+		Uid:             "dl-42",
+		TimeStart:       timestamppb.New(start),
+		TimeEnd:         timestamppb.New(end),
+		Status:          pb.FileDownlinkCompletionStatus_DOWNLINK_PARTIAL,
+		Source:          "flight-1",
+		SourcePath:      "/seq/image.raw",
+		DestinationPath: "/ground/image.raw",
+		FilePath:        "/data/hermes/image.raw",
+		MissingChunks: []*pb.FileDownlinkChunk{
+			{Offset: 100, Size: 50},
+			{Offset: 300, Size: 25},
+		},
+		DuplicateChunks: []*pb.FileDownlinkChunk{
+			{Offset: 0, Size: 10},
+		},
+		Size:     2048,
+		Metadata: map[string]string{"camera": `"nav"`},
+	}
+
+	args, err := downlinkArgs(msg)
+	if err != nil {
+		t.Fatalf("failed to build downlink args: %v", err)
+	}
+	if len(args) != 14 {
+		t.Fatalf("expected 14 insert args, got %d", len(args))
+	}
+
+	if args[0] != "dl-42" {
+		t.Errorf("uid: got %v", args[0])
+	}
+	if got := args[1].(stdtime.Time); !got.Equal(start) {
+		t.Errorf("timeStart: got %v", got)
+	}
+	if got := args[2].(stdtime.Time); !got.Equal(end) {
+		t.Errorf("timeEnd: got %v", got)
+	}
+	// The dashboard's value mappings key on the enum name, exactly what the
+	// old OTEL log path exported via Record().
+	if args[3] != "DOWNLINK_PARTIAL" {
+		t.Errorf("status: got %v", args[3])
+	}
+	if args[4] != "flight-1" || args[5] != "/seq/image.raw" ||
+		args[6] != "/ground/image.raw" || args[7] != "/data/hermes/image.raw" {
+		t.Errorf("string fields: got %v %v %v %v", args[4], args[5], args[6], args[7])
+	}
+	if args[8] != int64(2048) {
+		t.Errorf("fileSize should be int64 for the sql driver, got %T %v", args[8], args[8])
+	}
+
+	var missing []map[string]any
+	if err := json.Unmarshal([]byte(args[9].(string)), &missing); err != nil {
+		t.Fatalf("missingChunks is not valid JSON: %v", err)
+	}
+	if len(missing) != 2 {
+		t.Errorf("missingChunks: got %v", args[9])
+	}
+	if args[10] != int64(75) {
+		t.Errorf("missingBytes should sum chunk sizes, got %v", args[10])
+	}
+
+	var duplicate []map[string]any
+	if err := json.Unmarshal([]byte(args[11].(string)), &duplicate); err != nil {
+		t.Fatalf("duplicateChunks is not valid JSON: %v", err)
+	}
+	if len(duplicate) != 1 {
+		t.Errorf("duplicateChunks: got %v", args[11])
+	}
+	if args[12] != int64(10) {
+		t.Errorf("duplicateBytes should sum chunk sizes, got %v", args[12])
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal([]byte(args[13].(string)), &metadata); err != nil {
+		t.Fatalf("metadata is not valid JSON: %v", err)
+	}
+	if metadata["camera"] != `"nav"` {
+		t.Errorf("metadata: got %v", args[13])
+	}
+}
+
+func TestDownlinkArgsWithNoChunksStayValid(t *testing.T) {
+	// A clean completed downlink has no missing or duplicate chunks; JSONB
+	// columns still need valid JSON, not SQL nulls born from Go nils.
+	msg := &pb.FileDownlink{
+		Uid:     "dl-clean",
+		TimeEnd: timestamppb.New(stdtime.Date(2026, 7, 16, 11, 0, 0, 0, stdtime.UTC)),
+		Status:  pb.FileDownlinkCompletionStatus_DOWNLINK_COMPLETED,
+	}
+
+	args, err := downlinkArgs(msg)
+	if err != nil {
+		t.Fatalf("failed to build downlink args: %v", err)
+	}
+
+	if args[3] != "DOWNLINK_COMPLETED" {
+		t.Errorf("status: got %v", args[3])
+	}
+	if args[10] != int64(0) || args[12] != int64(0) {
+		t.Errorf("byte sums should be zero, got %v %v", args[10], args[12])
+	}
+	for _, i := range []int{9, 11, 13} {
+		if !json.Valid([]byte(args[i].(string))) {
+			t.Errorf("args[%d] should be valid JSON, got %v", i, args[i])
+		}
+	}
+}

--- a/pkg/timescaledb/schema.json
+++ b/pkg/timescaledb/schema.json
@@ -34,6 +34,12 @@
             "title": "Log Telemetry",
             "default": true,
             "description": "Push telemetry channels to this database."
+        },
+        "downlinks": {
+            "type": "boolean",
+            "title": "Log File Downlinks",
+            "default": true,
+            "description": "Push completed file downlink records to this database."
         }
     },
     "required": [

--- a/pkg/timescaledb/schema.sql
+++ b/pkg/timescaledb/schema.sql
@@ -74,3 +74,23 @@ CREATE TABLE IF NOT EXISTS telemetry (
 );
 
 SELECT add_dimension('telemetry', by_range('ert', INTERVAL '1 day'), if_not_exists => true);
+
+-- One row per finished file downlink. Low volume (a session emits a single
+-- record on completion), so a plain table — not a hypertable — is enough.
+CREATE TABLE IF NOT EXISTS fileDownlinks (
+    uid TEXT PRIMARY KEY,
+    timeStart TIMESTAMP WITH TIME ZONE,
+    timeEnd TIMESTAMP WITH TIME ZONE NOT NULL,
+    status TEXT,
+    source TEXT,
+    sourcePath TEXT,
+    destinationPath TEXT,
+    filePath TEXT,
+    fileSize BIGINT,
+    missingChunks JSONB,
+    missingBytes BIGINT,
+    duplicateChunks JSONB,
+    duplicateBytes BIGINT,
+    metadata JSONB,
+    ert TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/pkg/timescaledb/timescaledb.go
+++ b/pkg/timescaledb/timescaledb.go
@@ -20,7 +20,7 @@ var (
 //go:embed schema.json
 var schema string
 
-var uiSchema = `{"ui:order": ["host", "user", "password", "database", "events", "telemetry"]}`
+var uiSchema = `{"ui:order": ["host", "user", "password", "database", "events", "telemetry", "downlinks"]}`
 
 //go:embed schema.sql
 var schemaSql string
@@ -32,6 +32,7 @@ type Params struct {
 	Database  string `json:"database"`
 	Events    *bool  `json:"events,omitempty"`
 	Telemetry *bool  `json:"telemetry,omitempty"`
+	Downlinks *bool  `json:"downlinks,omitempty"`
 }
 
 // EventsEnabled reports whether events should be pushed. Profiles saved
@@ -44,6 +45,13 @@ func (p Params) EventsEnabled() bool {
 // saved before this option existed have no key and must stay enabled.
 func (p Params) TelemetryEnabled() bool {
 	return p.Telemetry == nil || *p.Telemetry
+}
+
+// DownlinksEnabled reports whether finished file downlinks should be pushed.
+// Profiles saved before this option existed have no key and must be enabled
+// so the downlink dashboard works without reconfiguration.
+func (p Params) DownlinksEnabled() bool {
+	return p.Downlinks == nil || *p.Downlinks
 }
 
 type timescaleDbProvider struct{}
@@ -107,6 +115,17 @@ func (t *timescaleDbProvider) Start(
 		})
 	} else {
 		session.Log().Info("telemetry logging to timescaledb is disabled by profile settings")
+	}
+
+	if settings.DownlinksEnabled() {
+		session.Log().Info("creating file downlink bus listener to push to timescaledb")
+		host.FileDownlink.On(ctx, func(msg *pb.FileDownlink) {
+			if err := InsertDownlink(ctx, db, msg); err != nil {
+				session.Log().Error("failed to insert file downlink to timescaledb", "err", err)
+			}
+		})
+	} else {
+		session.Log().Info("file downlink logging to timescaledb is disabled by profile settings")
 	}
 
 	<-ctx.Done()

--- a/timescale-stack/provisioning/dashboards/downlink.json
+++ b/timescale-stack/provisioning/dashboards/downlink.json
@@ -1,0 +1,273 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "DOWNLINK_COMPLETED": {
+                        "color": "dark-green",
+                        "index": 0,
+                        "text": "Completed"
+                      },
+                      "DOWNLINK_CRC_FAILED": {
+                        "color": "dark-red",
+                        "index": 2,
+                        "text": "CRC Failed"
+                      },
+                      "DOWNLINK_PARTIAL": {
+                        "color": "dark-red",
+                        "index": 1,
+                        "text": "Partial"
+                      },
+                      "DOWNLINK_UNKNOWN": {
+                        "color": "dark-red",
+                        "index": 3,
+                        "text": "Unknown"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "applyToRow": true,
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "End Time"
+            },
+            "properties": [
+              {
+                "id": "custom.minWidth",
+                "value": 170
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Agent"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Missing"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duplicate"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 19,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "md",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  timestart AS \"Start Time\",\n  timeend AS \"End Time\",\n  status AS \"Status\",\n  uid AS \"UID\",\n  source AS \"Agent\",\n  sourcepath AS \"Source\",\n  destinationpath AS \"Destination\",\n  (EXTRACT(EPOCH FROM (timeend - timestart)) * 1000) AS \"Duration\",\n  filesize AS \"Total\",\n  missingbytes AS \"Missing\",\n  duplicatebytes AS \"Duplicate\"\nFROM filedownlinks\nWHERE $__timeFilter(timeend)\nORDER BY timeend DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "transformations": [
+        {
+          "id": "formatTime",
+          "options": {
+            "outputFormat": "YYYY-MM-DD HH:mm:ss",
+            "timeField": "Start Time",
+            "useTimezone": true
+          }
+        },
+        {
+          "id": "formatTime",
+          "options": {
+            "outputFormat": "YYYY-MM-DD HH:mm:ss",
+            "timeField": "End Time",
+            "useTimezone": true
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "File Downlinks",
+  "uid": "hermes-downlinks",
+  "version": 1
+}

--- a/timescale-stack/provisioning/datasources/grafana-datasources.yml
+++ b/timescale-stack/provisioning/datasources/grafana-datasources.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: TimescaleDB
+    uid: timescaledb
     type: postgres
     access: proxy
     url: timescaledb:5432
@@ -10,6 +11,9 @@ datasources:
     secureJsonData:
       password: "password"
     jsonData:
+      # Modern Grafana reads the database from jsonData; the deprecated
+      # top-level key is kept for older releases.
+      database: hermes
       sslmode: "disable"
       timescaledb: true
     isDefault: true


### PR DESCRIPTION
## What this does
Makes the File Downlinks dashboard work again when running on TimescaleDB. Fixes #110.

## Why
After the move from the old otel-lgtm monitoring stack to TimescaleDB, finished file downlinks were no longer saved anywhere — so the dashboard had nothing to show and its old data source no longer existed.

## What changed
- The TimescaleDB profile now saves a record every time a file downlink finishes. It has an on/off switch in the profile settings, on by default — same as the existing events and telemetry switches.
- A new File Downlinks dashboard provisioned with the timescale stack — same columns, status colors, and layout as the original.
- Small data source fix: newer Grafana versions need the database name under `jsonData` and silently refuse to run dashboard queries without it.

## How to see it
1. `docker compose up` in `timescale-stack/`
2. Run hermes with a TimescaleDB profile and downlink a file
3. Open Grafana → Hermes folder → File Downlinks

## Screenshots

The dashboard rendering seeded downlinks — green rows completed, red rows partial / CRC-failed:

<img width="1523" height="784" alt="File Downlinks dashboard, full page" src="https://github.com/user-attachments/assets/1ad20053-0182-4154-860d-0e4ca6ffdfd3" />

<img width="1568" height="278" alt="File Downlinks table close-up" src="https://github.com/user-attachments/assets/7888c7f4-f1ef-49a9-889a-4d5c857e79dc" />

## Notes for reviewers
- Status is stored as the enum name (e.g. `DOWNLINK_COMPLETED`) — the exact strings the old dashboard's value mappings used.
- `fileDownlinks` is a plain table, not a hypertable — one low-volume row per finished downlink.
- 10 new unit tests in `pkg/timescaledb/downlink_test.go`, written test-first.
