### PR TITLE
Update CI/Docs with Versionless Grafana Plugin

### DIFF
--- a/.github/workflows/grafana-release.yml
+++ b/.github/workflows/grafana-release.yml
@@ -75,12 +75,14 @@ jobs:
           export GRAFANA_PLUGIN_TYPE=$(cat dist/plugin.json | jq -r .type)
           export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
           export GRAFANA_PLUGIN_ARTIFACT_SHA1SUM=${GRAFANA_PLUGIN_ARTIFACT}.sha1
+          export GRAFANA_PLUGIN_ARTIFACT_LATEST=${GRAFANA_PLUGIN_ID}.zip
 
           echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
           echo "plugin-version=${GRAFANA_PLUGIN_VERSION}" >> $GITHUB_OUTPUT
           echo "plugin-type=${GRAFANA_PLUGIN_TYPE}" >> $GITHUB_OUTPUT
           echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
           echo "archive-sha1sum=${GRAFANA_PLUGIN_ARTIFACT_SHA1SUM}" >> $GITHUB_OUTPUT
+          echo "archive-latest=${GRAFANA_PLUGIN_ARTIFACT_LATEST}" >> $GITHUB_OUTPUT
 
           echo "github-tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
         shell: bash
@@ -91,11 +93,13 @@ jobs:
           mv dist $PLUGIN_ID
           zip $PLUGIN_ARCHIVE $PLUGIN_ID -r
           sha1sum $PLUGIN_ARCHIVE | cut -f1 -d' ' > $PLUGIN_ARCHIVE_SHA1SUM
+          cp $PLUGIN_ARCHIVE $PLUGIN_ARCHIVE_LATEST
         shell: bash
         env:
           PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
           PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
           PLUGIN_ARCHIVE_SHA1SUM: ${{ steps.metadata.outputs.archive-sha1sum }}
+          PLUGIN_ARCHIVE_LATEST: ${{ steps.metadata.outputs.archive-latest }}
         working-directory: ./grafana-datasource-plugin
 
       - name: Validate plugin
@@ -109,5 +113,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
+            ./grafana-datasource-plugin/${{ steps.metadata.outputs.archive-latest }}
             ./grafana-datasource-plugin/${{ steps.metadata.outputs.archive }}
             ./grafana-datasource-plugin/${{ steps.metadata.outputs.archive-sha1sum }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/download/v5.0.0/nasa-hermes-datasource-5.0.0.zip;nasa-hermes-datasource"
+      GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/latest/download/nasa-hermes-datasource.zip;nasa-hermes-datasource"
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: nasa-hermes-datasource
     depends_on:
       timescaledb:

--- a/docs/tlm/grafana.md
+++ b/docs/tlm/grafana.md
@@ -47,7 +47,9 @@ Restart Grafana after changing `grafana.ini`.
 
 ### Install to Docker Compose
 
-**This is the recommended approach.** Use Grafana's built-in `GF_INSTALL_PLUGINS` environment variable to install a specific pinned version of the plugin. This is the approach used in the default [`docker-compose.yml`](https://github.com/nasa/hermes/blob/main/docker-compose.yml):
+**This is the recommended approach.** Use Grafana's built-in `GF_INSTALL_PLUGINS` environment variable to install the plugin automatically. This is the approach used in the default [`docker-compose.yml`](https://github.com/nasa/hermes/blob/main/docker-compose.yml).
+
+The recommended URL uses GitHub's `latest` redirect so you always track the newest release without editing the version by hand:
 
 ```diff
 services:
@@ -57,7 +59,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-+     GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/download/v5.0.0/nasa-hermes-datasource-5.0.0.zip;nasa-hermes-datasource"
++     GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/latest/download/nasa-hermes-datasource.zip;nasa-hermes-datasource"
 +     GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "nasa-hermes-datasource"
     volumes:
       - grafana-data:/var/lib/grafana
@@ -66,7 +68,15 @@ volumes:
   grafana-data:
 ```
 
-The plugin is downloaded and installed automatically when the container starts. To upgrade to a newer version, update the release URL in `GF_INSTALL_PLUGINS` to point to the desired version from the [releases page](https://github.com/nasa/hermes/releases) and recreate the container.
+The plugin is downloaded and installed automatically when the container starts. Recreating the container picks up the newest release automatically. `latest` tracks the most recent non-prerelease release.
+
+If you prefer to pin a specific version instead, point `GF_INSTALL_PLUGINS` at a versioned release URL from the [releases page](https://github.com/nasa/hermes/releases) and update it when upgrading:
+
+```yaml
+    environment:
+      GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/download/v5.0.0/nasa-hermes-datasource-5.0.0.zip;nasa-hermes-datasource"
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "nasa-hermes-datasource"
+```
 
 ### Install to an Existing Grafana Instance
 


### PR DESCRIPTION
This allows users to download the latest version of the plugin by default in their docker compose by requesting the latest version, which GitHub resolves correctly.