### PR TITLE
Fix F Prime Integration Tests

### DIFF
--- a/docker/Dockerfile.fprime
+++ b/docker/Dockerfile.fprime
@@ -49,6 +49,9 @@ RUN rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 
+# F Prime expects this directory to exist at runtime (whitelisted for file uplink)
+RUN mkdir -p /tmp/uplink
+
 # Copy virtual environment and built artifacts from builder
 COPY --from=fprime-builder /workspace/fprime/TestDeploymentsProject/build-artifacts /workspace
 
@@ -65,6 +68,10 @@ GROUND_ADDRESS=\$(getent hosts "\${GROUND_ADDRESS}" | awk '{ print \$1 }')
 echo "Launching F Prime Ref deployment"
 echo "Ground Hostname: \${GROUND_ADDRESS_ORIG} (\${GROUND_ADDRESS})"
 echo "Ground Port: \${GROUND_PORT}"
+
+
+# Change to the uplink directory where F Prime expects files to be uplinked
+cd /tmp/uplink
 
 exec /workspace/Linux/Ref/bin/Ref -a \${GROUND_ADDRESS} -p \${GROUND_PORT}
 EOF


### PR DESCRIPTION
To our understanding, [this](https://github.com/nasa/fprime/commit/4c8b9c0b8692b0d47cbd5f2ccec61c74aa02b893) F Prime commit introduced a new requirement for uplinked files.
```diff
+ // Restrict uplinked files to a sandbox directory to prevent path-traversal writes
+ FileHandling::fileUplink.configure("/tmp/uplink/");
```
Therefore, we have updated the Dockerfile to create and enter this directory (since it appears that F Prime expects this directory to exist).