### PR TITLE
Add plugin builds to releases during passing ci

### DIFF
--- a/.github/workflows/grafana-ci.yml
+++ b/.github/workflows/grafana-ci.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'grafana-datasource-plugin/**'
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     branches:
       - master
       - main
@@ -21,6 +22,7 @@ jobs:
   build:
     name: Build, lint and unit tests
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'closed' }}
     defaults:
       run:
         working-directory: ./grafana-datasource-plugin
@@ -237,3 +239,87 @@ jobs:
       #     name: ${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}-server-log
       #     path: grafana-server.log
       #     retention-days: 5
+
+  publish-dev:
+    name: Publish dev build to GitHub Releases
+    runs-on: ubuntu-latest
+    needs: build
+    if: >-
+      ${{ github.event_name == 'pull_request' && github.event.action != 'closed'
+          && github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: write
+    steps:
+      - name: Compute build metadata
+        id: meta
+        run: |
+          SHA="${{ github.event.pull_request.head.sha }}"
+          echo "pr-tag=grafana-plugin-pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "short=${SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Download built plugin
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
+          path: ${{ needs.build.outputs.plugin-id }}
+
+      - name: Package plugin
+        id: package
+        run: |
+          ROLLING="${PLUGIN_ID}.zip"
+          PINNED="${PLUGIN_ID}-${SHORT_SHA}.zip"
+          zip -r "${ROLLING}" "${PLUGIN_ID}"
+          cp "${ROLLING}" "${PINNED}"
+          sha1sum "${ROLLING}" | cut -f1 -d' ' > "${ROLLING}.sha1"
+          echo "rolling=${ROLLING}" >> "$GITHUB_OUTPUT"
+          echo "rolling-sha1=${ROLLING}.sha1" >> "$GITHUB_OUTPUT"
+          echo "pinned=${PINNED}" >> "$GITHUB_OUTPUT"
+        env:
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+          SHORT_SHA: ${{ steps.meta.outputs.short }}
+
+      - name: Publish rolling PR release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.pr-tag }}
+          name: Grafana plugin (PR #${{ github.event.pull_request.number }})
+          prerelease: true
+          body: |
+            Development build of the Grafana datasource plugin for pull request #${{ github.event.pull_request.number }}.
+            Commit: ${{ steps.meta.outputs.sha }}
+          files: |
+            ${{ steps.package.outputs.rolling }}
+            ${{ steps.package.outputs.rolling-sha1 }}
+
+      - name: Publish per-commit release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: grafana-plugin-${{ steps.meta.outputs.short }}
+          name: Grafana plugin (${{ steps.meta.outputs.short }})
+          prerelease: true
+          body: |
+            Development build of the Grafana datasource plugin.
+            Commit: ${{ steps.meta.outputs.sha }}
+          files: |
+            ${{ steps.package.outputs.pinned }}
+
+  cleanup-pr-release:
+    name: Delete per-PR dev release on close
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: write
+    steps:
+      - name: Delete PR release and tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TAG: grafana-plugin-pr-${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh release view "$PR_TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release delete "$PR_TAG" --repo "$REPO" --cleanup-tag --yes
+            echo "Deleted release and tag $PR_TAG"
+          else
+            echo "No release found for $PR_TAG; nothing to clean up."
+          fi

--- a/.github/workflows/grafana-ci.yml
+++ b/.github/workflows/grafana-ci.yml
@@ -255,7 +255,6 @@ jobs:
         run: |
           SHA="${{ github.event.pull_request.head.sha }}"
           echo "pr-tag=grafana-plugin-pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          echo "short=${SHA::7}" >> "$GITHUB_OUTPUT"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Download built plugin
@@ -268,22 +267,18 @@ jobs:
         id: package
         run: |
           ROLLING="${PLUGIN_ID}.zip"
-          PINNED="${PLUGIN_ID}-${SHORT_SHA}.zip"
           zip -r "${ROLLING}" "${PLUGIN_ID}"
-          cp "${ROLLING}" "${PINNED}"
           sha1sum "${ROLLING}" | cut -f1 -d' ' > "${ROLLING}.sha1"
           echo "rolling=${ROLLING}" >> "$GITHUB_OUTPUT"
           echo "rolling-sha1=${ROLLING}.sha1" >> "$GITHUB_OUTPUT"
-          echo "pinned=${PINNED}" >> "$GITHUB_OUTPUT"
         env:
           PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
-          SHORT_SHA: ${{ steps.meta.outputs.short }}
 
       - name: Publish rolling PR release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.meta.outputs.pr-tag }}
-          name: Grafana plugin (PR #${{ github.event.pull_request.number }})
+          name: "Grafana plugin (PR #${{ github.event.pull_request.number }})"
           prerelease: true
           body: |
             Development build of the Grafana datasource plugin for pull request #${{ github.event.pull_request.number }}.
@@ -291,18 +286,6 @@ jobs:
           files: |
             ${{ steps.package.outputs.rolling }}
             ${{ steps.package.outputs.rolling-sha1 }}
-
-      - name: Publish per-commit release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: grafana-plugin-${{ steps.meta.outputs.short }}
-          name: Grafana plugin (${{ steps.meta.outputs.short }})
-          prerelease: true
-          body: |
-            Development build of the Grafana datasource plugin.
-            Commit: ${{ steps.meta.outputs.sha }}
-          files: |
-            ${{ steps.package.outputs.pinned }}
 
   cleanup-pr-release:
     name: Delete per-PR dev release on close

--- a/.github/workflows/grafana-ci.yml
+++ b/.github/workflows/grafana-ci.yml
@@ -249,6 +249,7 @@ jobs:
           && github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Compute build metadata
         id: meta
@@ -286,6 +287,46 @@ jobs:
           files: |
             ${{ steps.package.outputs.rolling }}
             ${{ steps.package.outputs.rolling-sha1 }}
+
+      - name: Comment plugin build link on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TAG: ${{ steps.meta.outputs.pr-tag }}
+          SHA: ${{ steps.meta.outputs.sha }}
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+        run: |
+          MARKER="<!-- grafana-plugin-build -->"
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/${PR_TAG}"
+          ZIP_URL="https://github.com/${REPO}/releases/download/${PR_TAG}/${PLUGIN_ID}.zip"
+          SHORT_SHA="${SHA:0:7}"
+
+          BODY=$(cat <<EOF
+          ${MARKER}
+          ### Grafana plugin dev build
+
+          A development build of the Grafana datasource plugin is available for this PR (updated on every push).
+
+          - **Release:** [${PR_TAG}](${RELEASE_URL})
+          - **Download:** [\`${PLUGIN_ID}.zip\`](${ZIP_URL})
+          - **Commit:** \`${SHORT_SHA}\`
+
+          To try it, set \`GF_INSTALL_PLUGINS\` to \`${ZIP_URL};${PLUGIN_ID}\`.
+          EOF
+          )
+
+          # Find an existing sticky comment (by marker) and update it, else create one.
+          COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq "map(select(.body | contains(\"${MARKER}\"))) | .[0].id // empty")
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" -f body="$BODY" >/dev/null
+            echo "Updated sticky comment $COMMENT_ID"
+          else
+            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$BODY" >/dev/null
+            echo "Created sticky comment"
+          fi
 
   cleanup-pr-release:
     name: Delete per-PR dev release on close

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/latest/download/nasa-hermes-datasource.zip;nasa-hermes-datasource,https://github.com/nasa-jpl/honeycomb/releases/latest/download/jpl-honeycomb-panel.zip;jpl-honeycomb-panel"
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: nasa-hermes-datasource,jpl-honeycomb-panel
+      GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/latest/download/nasa-hermes-datasource.zip;nasa-hermes-datasource"
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: nasa-hermes-datasource
     depends_on:
       timescaledb:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/latest/download/nasa-hermes-datasource.zip;nasa-hermes-datasource"
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: nasa-hermes-datasource
+      GF_INSTALL_PLUGINS: "https://github.com/nasa/hermes/releases/latest/download/nasa-hermes-datasource.zip;nasa-hermes-datasource,https://github.com/nasa-jpl/honeycomb/releases/latest/download/jpl-honeycomb-panel.zip;jpl-honeycomb-panel"
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: nasa-hermes-datasource,jpl-honeycomb-panel
     depends_on:
       timescaledb:
         condition: service_started

--- a/grafana-datasource-plugin/README.md
+++ b/grafana-datasource-plugin/README.md
@@ -65,7 +65,7 @@ npm run lint:fix
 
 The Grafana plugin is released together with the VSCode extensions as part of the unified release process. Releasing a tag with the `v*` prefix (e.g., `v4.1.0`) will trigger a release build that includes both the VSCode extensions and the Grafana plugin. The workflow creates a release with all artifacts attached.
 
-Additionally, PRs that modify the plugin will trigger a CI build that includes the plugin artifacts.
+Additionally, PRs that modify the plugin will trigger a CI build that includes the plugin artifacts with a backlink to the PR in the comment.
 
 ## Project Structure
 

--- a/grafana-datasource-plugin/README.md
+++ b/grafana-datasource-plugin/README.md
@@ -65,6 +65,8 @@ npm run lint:fix
 
 The Grafana plugin is released together with the VSCode extensions as part of the unified release process. Releasing a tag with the `v*` prefix (e.g., `v4.1.0`) will trigger a release build that includes both the VSCode extensions and the Grafana plugin. The workflow creates a release with all artifacts attached.
 
+Additionally, PRs that modify the plugin will trigger a CI build that includes the plugin artifacts.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
Updates the CI to deploy plugin builds for PRs which update as commits are pushed. Also includes a sticky comment to backlink to the release :)

On PR Close, this workflow will also delete the PR-related release.