### PR TITLE
Fix TestFPrimeTCP test race condition

### DIFF
--- a/pkg/fprime/stream_test.go
+++ b/pkg/fprime/stream_test.go
@@ -99,6 +99,9 @@ func TestFPrimeTCP(t *testing.T) {
 
 	wg.Wait()
 
+	assert.NoError(t, host.Event.Flush(t.Context()))
+	assert.NoError(t, host.Telemetry.Flush(t.Context()))
+
 	// Update reference files
 	// updateFile(t, "testdata/events.json", events)
 	// updateFile(t, "testdata/telemetry.json", telemetry)


### PR DESCRIPTION
Flushes the event/telemetry buses to wait until all messages are in lists (previously would only wait until completed emission onto the bus).

## Issues
Closes #184 