### PR TITLE
Support Value Transform in datasource plugin

### DIFF
--- a/grafana-datasource-plugin/src/README.md
+++ b/grafana-datasource-plugin/src/README.md
@@ -43,6 +43,31 @@ Select **Telemetry** in the bottom-right toggle. Queries time-series values from
 | **Aggregation** | select                 | Function applied per time bucket: `Average`, `Min`, `Max`, `Count`, `First`, `Last`, `Sum`, `Derivative`, `Raw (none)`.                   |
 | **Source**      | multi-select, optional | FSW source identifier. Leave empty to include all sources.                                                                                |
 | **Keys**        | multi-select, optional | Sub-field paths for compound (object/array) channels. Appears per-channel only when multiple keys exist. Leave empty to include all keys. |
+| **Value Transform** | text, optional     | *(Collapsible)* Rescale or convert values per channel, or per key for compound channels. See below.                                       |
+
+<br>
+
+##### Value Transform
+
+Each selected channel gets its own input. Enter a plain number to multiply by it, or any PostgreSQL expression using `$__value` in place of the stored value.
+
+| Input                       | Result                    |
+| --------------------------- | ------------------------- |
+| *(blank)*                   | No transform              |
+| `2`                         | `$__value * 2`            |
+| `0.001`                     | Milli → base units        |
+| `$__value - 273.15`         | Kelvin → Celsius          |
+| `$__value * 9.0/5.0 + 32`   | Celsius → Fahrenheit      |
+| `ABS($__value)`             | Any PostgreSQL function   |
+| `$__value * $gain`          | Combined with a dashboard variable |
+
+The transform is compiled into the generated SQL and applied before aggregation, so it carries over when you switch to Code mode and stays correct for `Min` / `Max` with negative factors.
+
+Notes:
+
+- Applies to **numeric channels only**. Boolean, string, and byte values are returned unchanged.
+- Use `$__value`, not `$v` — Grafana reserves the `$__` prefix, so the token can never be shadowed by a dashboard variable.
+- `Count` counts the transformed expression, so an expression that changes null-ness (such as `COALESCE($__value, 0)`) will also change the count.
 
 <br>
 

--- a/grafana-datasource-plugin/src/components/BuilderEditor.tsx
+++ b/grafana-datasource-plugin/src/components/BuilderEditor.tsx
@@ -34,6 +34,7 @@ export function BuilderEditor({ query, onChange, onRunQuery, datasource }: Build
       channels: [],
       keys: [],
       sources: [],
+      transforms: [],
     };
     onChange(updated);
     if (value === 'events') {
@@ -56,44 +57,51 @@ export function BuilderEditor({ query, onChange, onRunQuery, datasource }: Build
     onRunQuery();
   };
 
+  const sharedOptions = (
+    <div style={{ marginTop: 8, marginBottom: 8, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <RadioButtonGroup
+        id="query-editor-time-field"
+        options={TIME_FIELD_OPTIONS}
+        value={query.timeField ?? 'ert'}
+        onChange={onTimeFieldChange}
+        size="sm"
+        fullWidth={false}
+      />
+      <RadioButtonGroup
+        id="query-editor-query-type"
+        options={QUERY_TYPE_OPTIONS.filter(opt => opt.value !== 'raw')}
+        value={queryType}
+        onChange={onQueryTypeChange}
+        size="sm"
+        fullWidth={false}
+      />
+    </div>
+  );
+
   return (
     <>
-      {queryType === 'telemetry' && (
+      {queryType === 'telemetry' ? (
         <TelemetryFields
           query={query}
           onChange={onChange}
           onRunQuery={onRunQuery}
           datasource={datasource}
+          sharedOptions={sharedOptions}
         />
+      ) : (
+        <>
+          {queryType === 'events' && (
+            <EventFields
+              query={query}
+              onChange={onChange}
+              onRunQuery={onRunQuery}
+              datasource={datasource}
+            />
+          )}
+          {sharedOptions}
+        </>
       )}
 
-      {queryType === 'events' && (
-        <EventFields
-          query={query}
-          onChange={onChange}
-          onRunQuery={onRunQuery}
-          datasource={datasource}
-        />
-      )}
-
-      <div style={{ marginTop: 8, marginBottom: 8, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <RadioButtonGroup
-          id="query-editor-time-field"
-          options={TIME_FIELD_OPTIONS}
-          value={query.timeField ?? 'ert'}
-          onChange={onTimeFieldChange}
-          size="sm"
-          fullWidth={false}
-        />
-        <RadioButtonGroup
-          id="query-editor-query-type"
-          options={QUERY_TYPE_OPTIONS.filter(opt => opt.value !== 'raw')}
-          value={queryType}
-          onChange={onQueryTypeChange}
-          size="sm"
-          fullWidth={false}
-        />
-      </div>
       <CollapsableSection label="Advanced" isOpen={false}>
         <InlineField label="From Override" labelWidth={16} tooltip="Absolute start time (optional)">
           <DateTimePicker

--- a/grafana-datasource-plugin/src/components/QueryEditor.test.tsx
+++ b/grafana-datasource-plugin/src/components/QueryEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryEditor } from './QueryEditor';
 import { DataSource } from '../datasource';
 import { ChannelRef, DEFAULT_QUERY, MyDataSourceOptions, MyQuery, withDefaults } from '../types';
@@ -432,6 +432,163 @@ describe('QueryEditor — Multi-select', () => {
 
     // MultiCombobox in jsdom may only render visible pills
     expect(screen.getByText('fsw-1')).toBeInTheDocument();
+  });
+});
+
+describe('QueryEditor — Value transforms', () => {
+  const scalarDs = () =>
+    mockDatasource({
+      getKeys: jest.fn().mockResolvedValue([{ component: 'CDH', channel: 'Temperature', key: 'value' }]),
+    });
+
+  const telemetryQuery = (overrides?: Partial<MyQuery>): MyQuery =>
+    ({
+      refId: 'A',
+      queryType: 'telemetry',
+      channels: [ch('CDH', 'Temperature')],
+      sources: [],
+      keys: [],
+      aggregation: 'avg',
+      ...overrides,
+    }) as MyQuery;
+
+  // The section is collapsed until the query carries a transform, and
+  // CollapsableSection unmounts its children while closed.
+  async function expandSection() {
+    const header = await screen.findByTestId('query-editor-transform-section');
+    await act(async () => {
+      fireEvent.click(header);
+    });
+  }
+
+  it('renders one transform input for a scalar channel', async () => {
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query: telemetryQuery() })} />);
+    await expandSection();
+
+    expect(screen.getByTestId('query-editor-transform-CDH.Temperature')).toBeInTheDocument();
+  });
+
+  it('renders one transform input per key for a compound channel', async () => {
+    const ds = mockDatasource({
+      getKeys: jest.fn().mockResolvedValue([
+        { component: 'CDH', channel: 'Temperature', key: 'value.x' },
+        { component: 'CDH', channel: 'Temperature', key: 'value.y' },
+      ]),
+    });
+    const query = telemetryQuery({
+      keys: [
+        { component: 'CDH', channel: 'Temperature', key: 'value.x' },
+        { component: 'CDH', channel: 'Temperature', key: 'value.y' },
+      ],
+    });
+    render(<QueryEditor {...buildProps({ datasource: ds, query })} />);
+    await expandSection();
+
+    expect(screen.getByTestId('query-editor-transform-CDH.Temperature.value.x')).toBeInTheDocument();
+    expect(screen.getByTestId('query-editor-transform-CDH.Temperature.value.y')).toBeInTheDocument();
+    expect(screen.queryByTestId('query-editor-transform-CDH.Temperature')).not.toBeInTheDocument();
+  });
+
+  it('renders no transform section when no channel is selected', async () => {
+    await act(async () => {
+      render(<QueryEditor {...buildProps()} />);
+    });
+
+    expect(screen.queryByTestId('query-editor-transform-section')).not.toBeInTheDocument();
+  });
+
+  it('renders the shared toggles above the Value Transform section', async () => {
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query: telemetryQuery() })} />);
+
+    const section = await screen.findByTestId('query-editor-transform-section');
+    const timeFieldToggle = screen.getByRole('radio', { name: /Receive Time/ });
+
+    expect(
+      timeFieldToggle.compareDocumentPosition(section) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('starts expanded when the query already carries a transform', async () => {
+    const query = telemetryQuery({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2' }],
+    });
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query })} />);
+
+    expect(await screen.findByTestId('query-editor-transform-CDH.Temperature')).toBeInTheDocument();
+  });
+
+  it('writes the raw input into query.transforms', async () => {
+    const onChange = jest.fn();
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query: telemetryQuery(), onChange })} />);
+    await expandSection();
+
+    const input = screen.getByTestId('query-editor-transform-CDH.Temperature');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '2' } });
+    });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transforms: [{ component: 'CDH', channel: 'Temperature', targetKey: undefined, expr: '2' }],
+      })
+    );
+  });
+
+  it('round-trips an expression back into the input', async () => {
+    const query = telemetryQuery({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$__value - 273.15' }],
+    });
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query })} />);
+
+    const input = await screen.findByTestId('query-editor-transform-CDH.Temperature');
+    expect(input).toHaveValue('$__value - 273.15');
+  });
+
+  it('removes the entry when the input is cleared', async () => {
+    const onChange = jest.fn();
+    const query = telemetryQuery({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2' }],
+    });
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query, onChange })} />);
+
+    const input = await screen.findByTestId('query-editor-transform-CDH.Temperature');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ transforms: [] }));
+  });
+
+  it('shows a validation message and does not run an invalid expression', async () => {
+    const onRunQuery = jest.fn();
+    const query = telemetryQuery({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: 'twice' }],
+    });
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query, onRunQuery })} />);
+
+    const input = await screen.findByTestId('query-editor-transform-CDH.Temperature');
+    expect(screen.getByText(/must reference \$__value/)).toBeInTheDocument();
+
+    onRunQuery.mockClear();
+    await act(async () => {
+      fireEvent.blur(input);
+    });
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('runs the query on blur when the expression is valid', async () => {
+    const onRunQuery = jest.fn();
+    const query = telemetryQuery({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2' }],
+    });
+    render(<QueryEditor {...buildProps({ datasource: scalarDs(), query, onRunQuery })} />);
+
+    const input = await screen.findByTestId('query-editor-transform-CDH.Temperature');
+    onRunQuery.mockClear();
+    await act(async () => {
+      fireEvent.blur(input);
+    });
+    expect(onRunQuery).toHaveBeenCalled();
   });
 });
 

--- a/grafana-datasource-plugin/src/components/QueryEditor.tsx
+++ b/grafana-datasource-plugin/src/components/QueryEditor.tsx
@@ -7,7 +7,7 @@ import { DataSource } from '../datasource';
 import { MyDataSourceOptions, MyQuery, ResolvedQuery, withDefaults } from '../types';
 import { BuilderEditor } from './BuilderEditor';
 import { SqlEditor } from './SqlEditor';
-import { buildQuery, resolveChannels } from '../query';
+import { buildQuery, resolveQuery } from '../query';
 
 type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
 
@@ -44,10 +44,7 @@ export function QueryEditor({ query, onChange, onRunQuery, datasource, range }: 
         const templateSrv = getTemplateSrv();
         const needsChannels = (filled.channels ?? []).some((c) => c.raw !== undefined);
         const known = needsChannels ? await datasource.getChannels().catch(() => []) : [];
-        const resolved: ResolvedQuery = {
-          ...filled,
-          channels: resolveChannels(filled.channels ?? [], (value) => templateSrv.replace(value), known),
-        };
+        const resolved: ResolvedQuery = resolveQuery(filled, (value) => templateSrv.replace(value), known);
         const from = range?.from ?? dateTime();
         const to = range?.to ?? dateTime();
         const sql = buildQuery(resolved, { range: { from, to, raw: { from, to } } } as any);

--- a/grafana-datasource-plugin/src/components/TelemetryFields.tsx
+++ b/grafana-datasource-plugin/src/components/TelemetryFields.tsx
@@ -1,14 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { Combobox, ComboboxOption, InlineField, MultiCombobox } from '@grafana/ui';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from '../datasource';
 import { Aggregation, ChannelQuery, ChannelRef, KeyRef, MyQuery } from '../types';
+import { TransformFields } from './TransformFields';
 
 interface TelemetryFieldsProps {
   query: MyQuery;
   onChange: (query: MyQuery) => void;
   onRunQuery: () => void;
   datasource: DataSource;
+  sharedOptions?: ReactNode;
 }
 
 const AGGREGATION_OPTIONS: Array<ComboboxOption<Aggregation>> = [
@@ -107,7 +109,7 @@ function isVariableReference(input: string): boolean {
   return refs.every((name) => defined.has(name));
 }
 
-export function TelemetryFields({ query, onChange, onRunQuery, datasource }: TelemetryFieldsProps) {
+export function TelemetryFields({ query, onChange, onRunQuery, datasource, sharedOptions }: TelemetryFieldsProps) {
   const [channelOptions, setChannelOptions] = useState<Array<ComboboxOption<string>>>([]);
   const [sourceOptions, setSourceOptions] = useState<Array<ComboboxOption<string>>>([]);
   const [keysByChannel, setKeysByChannel] = useState<Record<string, KeyRef[]>>({});
@@ -179,7 +181,7 @@ export function TelemetryFields({ query, onChange, onRunQuery, datasource }: Tel
       })
       .filter((ch): ch is ChannelQuery => ch !== null);
 
-    const updated: MyQuery = { ...query, channels, keys: [], sources: [] };
+    const updated: MyQuery = { ...query, channels, keys: [], sources: [], transforms: [] };
     onChange(updated);
     if (channels.length) {
       onRunQuery();
@@ -204,7 +206,19 @@ export function TelemetryFields({ query, onChange, onRunQuery, datasource }: Tel
     const channels = newKeys.length === 0
       ? (query.channels ?? []).filter((ch) => !(ch.component === chComponent && ch.name === chName))
       : query.channels;
-    const updated: MyQuery = { ...query, channels, keys: [...otherKeys, ...newKeys] };
+
+    const keptKeys = new Set(newKeys.map((k) => k.key));
+    const transforms = (query.transforms ?? []).filter((t) => {
+      if (t.component !== chComponent || t.channel !== chName) {
+        return true;
+      }
+      if (newKeys.length === 0) {
+        return false;
+      }
+      return t.targetKey === undefined || keptKeys.has(t.targetKey);
+    });
+
+    const updated: MyQuery = { ...query, channels, keys: [...otherKeys, ...newKeys], transforms };
     onChange(updated);
     if (updated.channels.length) {
       onRunQuery();
@@ -355,6 +369,13 @@ export function TelemetryFields({ query, onChange, onRunQuery, datasource }: Tel
             </InlineField>
           );
         })}
+      {sharedOptions}
+      <TransformFields
+        query={query}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        keysByChannel={keysByChannel}
+      />
     </>
   );
 }

--- a/grafana-datasource-plugin/src/components/TransformFields.test.tsx
+++ b/grafana-datasource-plugin/src/components/TransformFields.test.tsx
@@ -58,6 +58,23 @@ describe('TransformFields — template variable shorthand', () => {
     expect(input).toHaveValue('$num');
     // ...but it is not flagged as invalid (validation runs on the expansion).
     expect(screen.queryByText(/must reference \$__value/)).not.toBeInTheDocument();
+    // ...and the resolved-expression hint reflects the expansion.
+    const hint = screen.getByTestId('query-editor-transform-preview-CDH.Temperature');
+    expect(hint).toHaveAttribute('title', '= $__value * 8');
+  });
+
+  it('shows the resolved-expression hint when a template variable is used in a full expression', () => {
+    vars = { gain: '2' };
+    renderFields({ transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$__value * $gain' }] });
+
+    const hint = screen.getByTestId('query-editor-transform-preview-CDH.Temperature');
+    expect(hint).toHaveAttribute('title', '= $__value * 2');
+  });
+
+  it('shows no resolved-expression hint when the expression has no variables or shorthand', () => {
+    renderFields({ transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$__value * 2' }] });
+
+    expect(screen.queryByTestId('query-editor-transform-preview-CDH.Temperature')).not.toBeInTheDocument();
   });
 
   it('runs the query on blur when a variable resolves to a bare number', () => {

--- a/grafana-datasource-plugin/src/components/TransformFields.test.tsx
+++ b/grafana-datasource-plugin/src/components/TransformFields.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { TransformFields } from './TransformFields';
+import { KeyRef, MyQuery } from '../types';
+
+// Controllable template-variable substitution: replace $name with vars[name]
+// when defined, otherwise leave the text in place (mirrors templateSrv.replace).
+let vars: Record<string, string> = {};
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => ({
+    replace: (value: string) =>
+      (value ?? '').replace(/\$\w+/g, (m: string) => (m.slice(1) in vars ? vars[m.slice(1)] : m)),
+    getVariables: () => [],
+    containsTemplate: () => false,
+  }),
+}));
+
+const SCALAR_KEYS: Record<string, KeyRef[]> = {
+  'CDH.Temperature': [{ component: 'CDH', channel: 'Temperature', key: 'value' }],
+};
+
+function query(overrides?: Partial<MyQuery>): MyQuery {
+  return {
+    refId: 'A',
+    queryType: 'telemetry',
+    channels: [{ component: 'CDH', name: 'Temperature' }],
+    sources: [],
+    keys: [],
+    aggregation: 'avg',
+    ...overrides,
+  } as MyQuery;
+}
+
+function renderFields(overrides?: Partial<MyQuery>, onRunQuery = jest.fn(), onChange = jest.fn()) {
+  render(
+    <TransformFields
+      query={query(overrides)}
+      onChange={onChange}
+      onRunQuery={onRunQuery}
+      keysByChannel={SCALAR_KEYS}
+    />
+  );
+  return { onRunQuery, onChange };
+}
+
+beforeEach(() => {
+  vars = {};
+});
+
+describe('TransformFields — template variable shorthand', () => {
+  it('treats a variable that resolves to a bare number as a valid shorthand', () => {
+    vars = { num: '8' };
+    renderFields({ transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$num' }] });
+
+    const input = screen.getByTestId('query-editor-transform-CDH.Temperature');
+    // The raw variable reference is preserved in the field...
+    expect(input).toHaveValue('$num');
+    // ...but it is not flagged as invalid (validation runs on the expansion).
+    expect(screen.queryByText(/must reference \$__value/)).not.toBeInTheDocument();
+  });
+
+  it('runs the query on blur when a variable resolves to a bare number', () => {
+    vars = { num: '8' };
+    const { onRunQuery } = renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$num' }],
+    });
+
+    const input = screen.getByTestId('query-editor-transform-CDH.Temperature');
+    onRunQuery.mockClear();
+    act(() => {
+      fireEvent.blur(input);
+    });
+    expect(onRunQuery).toHaveBeenCalled();
+  });
+
+  it('still flags a variable that resolves to a non-numeric, tokenless string', () => {
+    vars = { bad: 'twice' };
+    const { onRunQuery } = renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$bad' }],
+    });
+
+    const input = screen.getByTestId('query-editor-transform-CDH.Temperature');
+    expect(screen.getByText(/must reference \$__value/)).toBeInTheDocument();
+
+    onRunQuery.mockClear();
+    act(() => {
+      fireEvent.blur(input);
+    });
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('stores the raw variable reference, not its expansion', () => {
+    vars = { num: '8' };
+    const { onChange } = renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$num' }],
+    });
+
+    const input = screen.getByTestId('query-editor-transform-CDH.Temperature');
+    act(() => {
+      fireEvent.change(input, { target: { value: '$gain' } });
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transforms: [{ component: 'CDH', channel: 'Temperature', targetKey: undefined, expr: '$gain' }],
+      })
+    );
+  });
+});

--- a/grafana-datasource-plugin/src/components/TransformFields.tsx
+++ b/grafana-datasource-plugin/src/components/TransformFields.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { CollapsableSection, Icon, InlineField, Input, Tooltip } from '@grafana/ui';
+import { KeyRef, MyQuery, TransformRef } from '../types';
+import { normalizeTransform, validateTransformInput, VALUE_TOKEN } from '../query';
+
+interface TransformFieldsProps {
+  query: MyQuery;
+  onChange: (query: MyQuery) => void;
+  onRunQuery: () => void;
+  keysByChannel: Record<string, KeyRef[]>;
+}
+
+interface TransformRow {
+  id: string;
+  component: string;
+  channel: string;
+  targetKey?: string;
+  label: string;
+}
+
+const SYNTAX_HELP = (
+  <div>
+    <p>
+      Enter a plain number to multiply by it, or any PostgreSQL expression using{' '}
+      <code>{VALUE_TOKEN}</code> for the stored value.
+    </p>
+    <p>
+      Examples: <code>2</code>, <code>0.001</code>, <code>{`${VALUE_TOKEN} - 273.15`}</code>,{' '}
+      <code>{`${VALUE_TOKEN} * 9.0/5.0 + 32`}</code>, <code>{`ABS(${VALUE_TOKEN})`}</code>
+    </p>
+    <p>Applies to numeric channels only. Boolean, string, and byte values are unaffected.</p>
+  </div>
+);
+
+export function transformId(component: string, channel: string, targetKey?: string): string {
+  return `${component}\0${channel}\0${targetKey ?? ''}`;
+}
+
+function matchesRow(t: TransformRef, row: TransformRow): boolean {
+  return transformId(t.component, t.channel, t.targetKey) === row.id;
+}
+
+export function buildTransformRows(
+  keysByChannel: Record<string, KeyRef[]>,
+  selectedKeys: KeyRef[]
+): TransformRow[] {
+  const rows: TransformRow[] = [];
+  for (const keys of Object.values(keysByChannel)) {
+    if (!keys.length) {
+      continue;
+    }
+    const { component, channel } = keys[0];
+    if (keys.length <= 1) {
+      rows.push({
+        id: transformId(component, channel),
+        component,
+        channel,
+        label: `${component}.${channel}`,
+      });
+      continue;
+    }
+    const selectedForChannel = selectedKeys.filter(
+      (k) => k.component === component && k.channel === channel
+    );
+    const forChannel = selectedForChannel.length ? selectedForChannel : keys;
+    for (const k of forChannel) {
+      rows.push({
+        id: transformId(component, channel, k.key),
+        component,
+        channel,
+        targetKey: k.key,
+        label: `${component}.${channel}.${k.key}`,
+      });
+    }
+  }
+  return rows;
+}
+
+export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: TransformFieldsProps) {
+  const rows = buildTransformRows(keysByChannel, query.keys ?? []);
+  if (!rows.length) {
+    return null;
+  }
+
+  const transforms = query.transforms ?? [];
+
+  const valueFor = (row: TransformRow): string =>
+    transforms.find((t) => matchesRow(t, row))?.expr ?? '';
+
+  const onExprChange = (row: TransformRow, raw: string) => {
+    const others = transforms.filter((t) => !matchesRow(t, row));
+    const next = raw.trim()
+      ? [...others, { component: row.component, channel: row.channel, targetKey: row.targetKey, expr: raw }]
+      : others;
+    onChange({ ...query, transforms: next });
+  };
+
+  const runIfValid = (row: TransformRow) => {
+    if (!validateTransformInput(valueFor(row))) {
+      onRunQuery();
+    }
+  };
+
+  return (
+    <CollapsableSection
+      label="Value Transform"
+      isOpen={transforms.length > 0}
+      headerDataTestId="query-editor-transform-section"
+    >
+      {rows.map((row, index) => {
+        const raw = valueFor(row);
+        const error = validateTransformInput(raw);
+        const normalized = normalizeTransform(raw);
+        const isShorthand = normalized !== undefined && !error && normalized !== raw.trim();
+        const inputId = `query-editor-transform-${index}`;
+        return (
+          <InlineField
+            key={row.id}
+            label={row.label}
+            tooltip={SYNTAX_HELP}
+            interactive
+            invalid={!!error}
+            error={error}
+            grow
+            shrink
+          >
+            <Input
+              id={inputId}
+              data-testid={`query-editor-transform-${row.label}`}
+              value={raw}
+              placeholder={VALUE_TOKEN}
+              invalid={!!error}
+              prefix={<Icon name="calculator-alt" />}
+              suffix={
+                isShorthand ? (
+                  <Tooltip content={`= ${normalized}`}>
+                    <Icon name="info-circle" />
+                  </Tooltip>
+                ) : undefined
+              }
+              onChange={(e) => onExprChange(row, e.currentTarget.value)}
+              onBlur={() => runIfValid(row)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  runIfValid(row);
+                }
+              }}
+            />
+          </InlineField>
+        );
+      })}
+    </CollapsableSection>
+  );
+}

--- a/grafana-datasource-plugin/src/components/TransformFields.tsx
+++ b/grafana-datasource-plugin/src/components/TransformFields.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CollapsableSection, Icon, InlineField, Input, Tooltip } from '@grafana/ui';
 import { getTemplateSrv } from '@grafana/runtime';
 import { KeyRef, MyQuery, TransformRef } from '../types';
-import { normalizeTransform, validateTransformInput, VALUE_TOKEN } from '../query';
+import { transformPreview, validateTransformInput, VALUE_TOKEN } from '../query';
 
 interface TransformFieldsProps {
   query: MyQuery;
@@ -112,10 +112,8 @@ export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: 
     >
       {rows.map((row, index) => {
         const raw = valueFor(row);
-        const expanded = expand(raw);
-        const error = validateTransformInput(expanded);
-        const normalized = normalizeTransform(expanded);
-        const isShorthand = normalized !== undefined && !error && normalized !== expanded.trim();
+        const error = validateTransformInput(expand(raw));
+        const preview = transformPreview(raw, expand);
         const inputId = `query-editor-transform-${index}`;
         return (
           <InlineField
@@ -136,9 +134,11 @@ export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: 
               invalid={!!error}
               prefix={<Icon name="calculator-alt" />}
               suffix={
-                isShorthand ? (
-                  <Tooltip content={`= ${normalized}`}>
-                    <Icon name="info-circle" />
+                preview ? (
+                  <Tooltip content={`= ${preview}`}>
+                    <span data-testid={`query-editor-transform-preview-${row.label}`} title={`= ${preview}`}>
+                      <Icon name="info-circle" />
+                    </span>
                   </Tooltip>
                 ) : undefined
               }

--- a/grafana-datasource-plugin/src/components/TransformFields.tsx
+++ b/grafana-datasource-plugin/src/components/TransformFields.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CollapsableSection, Icon, InlineField, Input, Tooltip } from '@grafana/ui';
+import { getTemplateSrv } from '@grafana/runtime';
 import { KeyRef, MyQuery, TransformRef } from '../types';
 import { normalizeTransform, validateTransformInput, VALUE_TOKEN } from '../query';
 
@@ -84,6 +85,8 @@ export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: 
 
   const transforms = query.transforms ?? [];
 
+  const expand = (raw: string) => getTemplateSrv().replace(raw);
+
   const valueFor = (row: TransformRow): string =>
     transforms.find((t) => matchesRow(t, row))?.expr ?? '';
 
@@ -96,7 +99,7 @@ export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: 
   };
 
   const runIfValid = (row: TransformRow) => {
-    if (!validateTransformInput(valueFor(row))) {
+    if (!validateTransformInput(expand(valueFor(row)))) {
       onRunQuery();
     }
   };
@@ -109,9 +112,10 @@ export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: 
     >
       {rows.map((row, index) => {
         const raw = valueFor(row);
-        const error = validateTransformInput(raw);
-        const normalized = normalizeTransform(raw);
-        const isShorthand = normalized !== undefined && !error && normalized !== raw.trim();
+        const expanded = expand(raw);
+        const error = validateTransformInput(expanded);
+        const normalized = normalizeTransform(expanded);
+        const isShorthand = normalized !== undefined && !error && normalized !== expanded.trim();
         const inputId = `query-editor-transform-${index}`;
         return (
           <InlineField

--- a/grafana-datasource-plugin/src/datasource.ts
+++ b/grafana-datasource-plugin/src/datasource.ts
@@ -67,6 +67,12 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
         channel: replace(k.channel),
         key: replace(k.key),
       })) ?? [],
+      transforms: query.transforms?.map(t => ({
+        component: replace(t.component),
+        channel: replace(t.channel),
+        targetKey: t.targetKey === undefined ? undefined : replace(t.targetKey),
+        expr: replace(t.expr),
+      })) ?? [],
     };
   }
 

--- a/grafana-datasource-plugin/src/datasource.ts
+++ b/grafana-datasource-plugin/src/datasource.ts
@@ -3,7 +3,7 @@ import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { from } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { MyQuery, MyDataSourceOptions, DEFAULT_QUERY, ChannelQuery, ChannelRef, KeyRef, ResolvedQuery, withDefaults } from './types';
-import { buildQuery, resolveChannels } from 'query';
+import { buildQuery, resolveChannels, resolveQuery } from 'query';
 
 export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptions> {
   private knownChannels?: Promise<ChannelRef[]>;
@@ -58,22 +58,7 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
   private resolveTargetVariables(query: MyQuery, scopedVars: ScopedVars, known: ChannelRef[] = []): ResolvedQuery {
     const templateSrv = getTemplateSrv();
     const replace = (value: string) => templateSrv.replace(value, scopedVars);
-    return {
-      ...query,
-      channels: resolveChannels(query.channels ?? [], replace, known),
-      sources: query.sources?.map(replace) ?? [],
-      keys: query.keys?.map(k => ({
-        component: replace(k.component),
-        channel: replace(k.channel),
-        key: replace(k.key),
-      })) ?? [],
-      transforms: query.transforms?.map(t => ({
-        component: replace(t.component),
-        channel: replace(t.channel),
-        targetKey: t.targetKey === undefined ? undefined : replace(t.targetKey),
-        expr: replace(t.expr),
-      })) ?? [],
-    };
+    return resolveQuery(query, replace, known);
   }
 
   filterQuery(query: MyQuery): boolean {

--- a/grafana-datasource-plugin/src/query.test.ts
+++ b/grafana-datasource-plugin/src/query.test.ts
@@ -4,6 +4,7 @@ import {
   buildTransformCase,
   normalizeTransform,
   resolveChannels,
+  transformPreview,
   validateExpression,
   validateTransformInput,
   VALUE_TOKEN,
@@ -329,6 +330,44 @@ describe('validateTransformInput', () => {
 
   it('rejects free text that is neither a number nor a token expression', () => {
     expect(validateTransformInput('twice')).toMatch(/must reference \$__value/);
+  });
+});
+
+describe('transformPreview', () => {
+  // Substitute $name with vars[name] when defined; otherwise leave in place
+  // (mirrors Grafana templateSrv.replace).
+  const expandWith = (vars: Record<string, string>) => (value: string) =>
+    value.replace(/\$\w+/g, (m) => (m.slice(1) in vars ? vars[m.slice(1)] : m));
+  const noVars = (value: string) => value;
+
+  it('previews the numeric shorthand expansion', () => {
+    expect(transformPreview('2', noVars)).toBe('$__value * 2');
+  });
+
+  it('previews a template variable used in a full expression', () => {
+    expect(transformPreview('$__value * $gain', expandWith({ gain: '2' }))).toBe('$__value * 2');
+  });
+
+  it('previews a template variable that resolves to a bare-number shorthand', () => {
+    expect(transformPreview('$num', expandWith({ num: '8' }))).toBe('$__value * 8');
+  });
+
+  it('returns undefined when the resolved expression matches the input', () => {
+    expect(transformPreview('$__value * 2', noVars)).toBeUndefined();
+  });
+
+  it('returns undefined for blank input', () => {
+    expect(transformPreview('', noVars)).toBeUndefined();
+    expect(transformPreview('   ', noVars)).toBeUndefined();
+  });
+
+  it('returns undefined when the resolved expression is invalid', () => {
+    expect(transformPreview('$bad', expandWith({ bad: 'twice' }))).toBeUndefined();
+    expect(transformPreview('$__value * ', noVars)).toBeUndefined();
+  });
+
+  it('ignores surrounding whitespace when deciding whether to preview', () => {
+    expect(transformPreview('  $__value * 2  ', noVars)).toBeUndefined();
   });
 });
 

--- a/grafana-datasource-plugin/src/query.test.ts
+++ b/grafana-datasource-plugin/src/query.test.ts
@@ -1,4 +1,13 @@
-import { buildTelemetryQuery, resolveChannels } from './query';
+import {
+  bindValueToken,
+  buildTelemetryQuery,
+  buildTransformCase,
+  normalizeTransform,
+  resolveChannels,
+  validateExpression,
+  validateTransformInput,
+  VALUE_TOKEN,
+} from './query';
 import { ChannelRef, MyQuery, ResolvedQuery } from './types';
 
 function baseQuery(overrides: Partial<ResolvedQuery>): ResolvedQuery {
@@ -247,5 +256,229 @@ describe('resolveChannels', () => {
     expect(resolveChannels([{ raw: '$component.Missing' }], replace, known)).toEqual([
       { component: 'CDH.Missing', name: '' },
     ]);
+  });
+});
+
+describe('normalizeTransform', () => {
+  it.each([
+    ['2', '$__value * 2'],
+    ['0.001', '$__value * 0.001'],
+    ['-1.5', '$__value * -1.5'],
+    ['+3', '$__value * +3'],
+    ['1e-3', '$__value * 1e-3'],
+    ['.5', '$__value * .5'],
+    ['  2  ', '$__value * 2'],
+  ])('expands the numeric shorthand %s -> %s', (raw, expected) => {
+    expect(normalizeTransform(raw)).toBe(expected);
+  });
+
+  it('passes an expression through verbatim, trimmed', () => {
+    expect(normalizeTransform('  $__value - 273.15 ')).toBe('$__value - 273.15');
+  });
+
+  it('returns undefined for blank input', () => {
+    expect(normalizeTransform('')).toBeUndefined();
+    expect(normalizeTransform('   ')).toBeUndefined();
+  });
+});
+
+describe('validateExpression', () => {
+  it('accepts expressions referencing the value token', () => {
+    expect(validateExpression('$__value * 2')).toBeUndefined();
+    expect(validateExpression('ABS($__value) - 1')).toBeUndefined();
+    expect(validateExpression("GREATEST($__value, 0)")).toBeUndefined();
+  });
+
+  it('requires the value token', () => {
+    expect(validateExpression('42 * 2')).toMatch(/must reference \$__value/);
+  });
+
+  it('suggests the correct token for near misses', () => {
+    expect(validateExpression('$v * 2')).toMatch(/Did you mean \$__value\?/);
+    expect(validateExpression('$value * 2')).toMatch(/Did you mean \$__value\?/);
+  });
+
+  it.each([
+    ['$__value * 2; DROP TABLE telemetry', /";"/],
+    ['$__value * 2 -- comment', /comments/],
+    ['$__value /* x */ * 2', /comments/],
+    ['ABS($__value * 2', /Unbalanced parentheses/],
+    ['ABS($__value) * 2)', /Unbalanced parentheses/],
+    ["$__value || 'abc", /Unbalanced quotes/],
+  ])('rejects %s', (expr, message) => {
+    expect(validateExpression(expr)).toMatch(message);
+  });
+});
+
+describe('validateTransformInput', () => {
+  it('treats blank input as valid (no transform)', () => {
+    expect(validateTransformInput('')).toBeUndefined();
+  });
+
+  it('accepts a bare number via the shorthand path', () => {
+    expect(validateTransformInput('2')).toBeUndefined();
+  });
+
+  it('rejects free text that is neither a number nor a token expression', () => {
+    expect(validateTransformInput('twice')).toMatch(/must reference \$__value/);
+  });
+});
+
+describe('bindValueToken', () => {
+  it('parenthesizes the column so precedence is preserved', () => {
+    expect(bindValueToken('$__value * 2', 't.floating::double precision')).toBe(
+      '(t.floating::double precision) * 2'
+    );
+    expect(bindValueToken('2 * $__value', 't.floating::double precision')).toBe(
+      '2 * (t.floating::double precision)'
+    );
+  });
+
+  it('binds every occurrence of the token', () => {
+    expect(bindValueToken('$__value * $__value', 'col')).toBe('(col) * (col)');
+  });
+});
+
+describe('buildTransformCase', () => {
+  const col = 't.floating::double precision';
+
+  it('returns the bare column when there are no transforms', () => {
+    expect(buildTransformCase(baseQuery({ channels: [{ component: 'CDH', name: 'Temperature' }] }), col)).toBe(col);
+  });
+
+  it('ignores transforms for channels that are not selected', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'Other', channel: 'Thing', expr: '2' }],
+    });
+    expect(buildTransformCase(q, col)).toBe(col);
+  });
+
+  it('ignores invalid transforms rather than emitting broken SQL', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$__value; DROP TABLE telemetry' }],
+    });
+    expect(buildTransformCase(q, col)).toBe(col);
+  });
+
+  it('orders key-specific branches before channel-wide ones', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Attitude' }],
+      transforms: [
+        { component: 'CDH', channel: 'Attitude', expr: '10' },
+        { component: 'CDH', channel: 'Attitude', targetKey: 'value.x', expr: '0.001' },
+      ],
+    });
+    const sql = buildTransformCase(q, col);
+    expect(sql.indexOf("t.key = 'value.x'")).toBeLessThan(sql.indexOf('THEN (t.floating::double precision) * 10'));
+  });
+
+  it('falls back to the bare column in the ELSE branch', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2' }],
+    });
+    expect(buildTransformCase(q, col)).toBe(
+      `CASE WHEN d.component = 'CDH' AND d.name = 'Temperature' THEN (${col}) * 2 ELSE ${col} END`
+    );
+  });
+
+  it('escapes quotes in component, channel, and key names', () => {
+    const q = baseQuery({
+      channels: [{ component: "O'Brien", name: 'Temp' }],
+      transforms: [{ component: "O'Brien", channel: 'Temp', targetKey: "a'b", expr: '2' }],
+    });
+    expect(buildTransformCase(q, col)).toContain("d.component = 'O''Brien'");
+    expect(buildTransformCase(q, col)).toContain("t.key = 'a''b'");
+  });
+});
+
+describe('buildTelemetryQuery — value transforms', () => {
+  const withTransform = (expr: string, targetKey?: string) =>
+    baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', targetKey, expr }],
+    });
+
+  it('leaves numeric columns untouched when no transform is set', () => {
+    const sql = buildTelemetryQuery(baseQuery({ channels: [{ component: 'CDH', name: 'Temperature' }] }), FROM, TO);
+    expect(sql).toContain('AVG(t.integral::double precision) AS val_int');
+    expect(sql).toContain('AVG(t.floating::double precision) AS val_float');
+    expect(sql).not.toContain('CASE');
+  });
+
+  it('binds the token to the matching column for each numeric output', () => {
+    const sql = buildTelemetryQuery(withTransform('2'), FROM, TO);
+    expect(sql).toContain('THEN (t.integral::double precision) * 2 ELSE t.integral::double precision END) AS val_int');
+    expect(sql).toContain('THEN (t.floating::double precision) * 2 ELSE t.floating::double precision END) AS val_float');
+  });
+
+  it('nests the transform inside the aggregate', () => {
+    const sql = buildTelemetryQuery(withTransform('$__value - 273.15'), FROM, TO);
+    expect(sql).toContain('AVG(CASE WHEN');
+    expect(sql).toContain('THEN (t.floating::double precision) - 273.15');
+  });
+
+  it('scopes a key-specific transform with an exact key match', () => {
+    const sql = buildTelemetryQuery(withTransform('0.001', 'value.x'), FROM, TO);
+    expect(sql).toContain("d.component = 'CDH' AND d.name = 'Temperature' AND t.key = 'value.x'");
+  });
+
+  it('never transforms the bool, string, or bytes columns', () => {
+    const sql = buildTelemetryQuery(withTransform('2'), FROM, TO);
+    expect(sql).toContain('AVG(t.boolval::int::double precision) AS val_bool');
+    expect(sql).toContain('NULL AS val_str');
+    expect(sql).toContain('NULL AS val_bytes');
+  });
+
+  it.each([['raw'], ['deriv']])('applies the transform without an aggregate wrapper for %s', (agg) => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      aggregation: agg as MyQuery['aggregation'],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2' }],
+    });
+    const sql = buildTelemetryQuery(q, FROM, TO);
+    expect(sql).toContain('END AS val_int');
+    expect(sql).not.toContain('AVG(CASE');
+    expect(sql).not.toContain('GROUP BY');
+  });
+
+  it('emits one branch per transformed channel', () => {
+    const q = baseQuery({
+      channels: [
+        { component: 'CDH', name: 'Temperature' },
+        { component: 'Sensors', name: 'Voltage' },
+      ],
+      transforms: [
+        { component: 'CDH', channel: 'Temperature', expr: '$__value - 273.15' },
+        { component: 'Sensors', channel: 'Voltage', expr: '0.001' },
+      ],
+    });
+    const sql = buildTelemetryQuery(q, FROM, TO);
+    expect(sql).toContain("WHEN d.component = 'CDH' AND d.name = 'Temperature' THEN (t.floating::double precision) - 273.15");
+    expect(sql).toContain("WHEN d.component = 'Sensors' AND d.name = 'Voltage' THEN (t.floating::double precision) * 0.001");
+  });
+});
+
+describe('value token vs. Grafana template expansion', () => {
+  // Mirrors Grafana's templateSrv.replace semantics: substitute $name when the
+  // variable exists, otherwise leave the text in place.
+  const replaceWith = (vars: Record<string, string>) => (value: string) =>
+    value.replace(/\$\w+/g, (m) => (m.slice(1) in vars ? vars[m.slice(1)] : m));
+
+  it('leaves the token intact while expanding other variables', () => {
+    const replace = replaceWith({ gain: '2' });
+    expect(replace('$__value * $gain')).toBe('$__value * 2');
+  });
+
+  it('is not clobbered by a dashboard variable named v', () => {
+    const replace = replaceWith({ v: '7' });
+    expect(replace(`${VALUE_TOKEN} * 2`)).toBe('$__value * 2');
+  });
+
+  it('routes a variable that resolves to a bare number through the shorthand path', () => {
+    const replace = replaceWith({ gain: '0.5' });
+    expect(normalizeTransform(replace('$gain'))).toBe('$__value * 0.5');
   });
 });

--- a/grafana-datasource-plugin/src/query.test.ts
+++ b/grafana-datasource-plugin/src/query.test.ts
@@ -287,6 +287,10 @@ describe('validateExpression', () => {
     expect(validateExpression('$__value * 2')).toBeUndefined();
     expect(validateExpression('ABS($__value) - 1')).toBeUndefined();
     expect(validateExpression("GREATEST($__value, 0)")).toBeUndefined();
+    expect(validateExpression('$__value * -3')).toBeUndefined();
+    expect(validateExpression('-$__value')).toBeUndefined();
+    expect(validateExpression("$__value || 'x'")).toBeUndefined();
+    expect(validateExpression('$__value >= 0')).toBeUndefined();
   });
 
   it('requires the value token', () => {
@@ -305,6 +309,10 @@ describe('validateExpression', () => {
     ['ABS($__value * 2', /Unbalanced parentheses/],
     ['ABS($__value) * 2)', /Unbalanced parentheses/],
     ["$__value || 'abc", /Unbalanced quotes/],
+    ['$__value * ', /cannot end with an operator/],
+    ['$__value +', /cannot end with an operator/],
+    ['* $__value', /cannot begin with an operator/],
+    ['/ $__value', /cannot begin with an operator/],
   ])('rejects %s', (expr, message) => {
     expect(validateExpression(expr)).toMatch(message);
   });

--- a/grafana-datasource-plugin/src/query.ts
+++ b/grafana-datasource-plugin/src/query.ts
@@ -1,5 +1,12 @@
-import { ChannelQuery, ChannelRef, ResolvedQuery } from "types";
+import { ChannelQuery, ChannelRef, ResolvedQuery, TransformRef } from "types";
 import { DataQueryRequest } from "@grafana/data";
+
+// token for user transforms
+export const VALUE_TOKEN = '$__value';
+
+const VALUE_TOKEN_PATTERN = /\$__value/g;
+const NUMERIC_PATTERN = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+const NEAR_MISS_PATTERN = /\$(v|value)\b/;
 
 
 // Resolve channel references to concrete { component, name } pairs.
@@ -19,6 +26,89 @@ export function resolveChannels(
         }
         return { component: expanded, name: '' };
     });
+}
+
+// Handle factor shorthand / full expression cases
+export function normalizeTransform(raw: string): string | undefined {
+    const trimmed = (raw ?? '').trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    if (NUMERIC_PATTERN.test(trimmed)) {
+        return `${VALUE_TOKEN} * ${trimmed}`;
+    }
+    return trimmed;
+}
+
+export function validateExpression(expr: string): string | undefined {
+    if (!expr.includes(VALUE_TOKEN)) {
+        if (NEAR_MISS_PATTERN.test(expr)) {
+            return `Unknown value token. Did you mean ${VALUE_TOKEN}?`;
+        }
+        return `Expression must reference ${VALUE_TOKEN} (or be a plain number).`;
+    }
+    if (expr.includes(';')) {
+        return 'Expression cannot contain ";".';
+    }
+    if (expr.includes('--') || expr.includes('/*') || expr.includes('*/')) {
+        return 'Expression cannot contain SQL comments.';
+    }
+    let depth = 0;
+    for (const ch of expr) {
+        if (ch === '(') {
+            depth++;
+        } else if (ch === ')') {
+            depth--;
+            if (depth < 0) {
+                return 'Unbalanced parentheses.';
+            }
+        }
+    }
+    if (depth !== 0) {
+        return 'Unbalanced parentheses.';
+    }
+    if ((expr.match(/'/g) ?? []).length % 2 !== 0) {
+        return 'Unbalanced quotes.';
+    }
+    return undefined;
+}
+
+export function validateTransformInput(raw: string): string | undefined {
+    const expr = normalizeTransform(raw);
+    return expr === undefined ? undefined : validateExpression(expr);
+}
+
+export function bindValueToken(expr: string, column: string): string {
+    return expr.replace(VALUE_TOKEN_PATTERN, `(${column})`);
+}
+
+function applicableTransforms(q: ResolvedQuery): Array<{ t: TransformRef; expr: string }> {
+    const channels = q.channels ?? [];
+    const matchesSelectedChannel = (t: TransformRef) =>
+        channels.some((ch) => t.component === ch.component && t.channel === ch.name);
+
+    const usable = (q.transforms ?? [])
+        .map((t) => ({ t, expr: normalizeTransform(t.expr) }))
+        .filter((e): e is { t: TransformRef; expr: string } => e.expr !== undefined)
+        .filter(({ expr }) => validateExpression(expr) === undefined)
+        .filter(({ t }) => matchesSelectedChannel(t));
+
+    return [...usable.filter(({ t }) => !!t.targetKey), ...usable.filter(({ t }) => !t.targetKey)];
+}
+
+export function buildTransformCase(q: ResolvedQuery, column: string): string {
+    const entries = applicableTransforms(q);
+    if (entries.length === 0) {
+        return column;
+    }
+    const branches = entries.map(({ t, expr }) => {
+        const conditions = [`d.component = ${esc(t.component)}`, `d.name = ${esc(t.channel)}`];
+        if (t.targetKey) {
+            conditions.push(`t.key = ${esc(t.targetKey)}`);
+        }
+        return `WHEN ${conditions.join(' AND ')} THEN ${bindValueToken(expr, column)}`;
+    });
+    return `CASE ${branches.join(' ')} ELSE ${column} END`;
 }
 
 export function buildQuery(q: ResolvedQuery, options: DataQueryRequest): string {
@@ -93,8 +183,9 @@ export function buildTelemetryQuery(q: ResolvedQuery, from: string, to: string):
         intervalExpr = `t.${q.timeField}`;
     }
 
-    const intCol = "t.integral::double precision";
-    const floatCol = "t.floating::double precision";
+    // Apply transforms to numeric columns ONLY
+    const intCol = buildTransformCase(q, "t.integral::double precision");
+    const floatCol = buildTransformCase(q, "t.floating::double precision");
     const boolCol = "t.boolval::int::double precision";
     const strCol = "t.string";
     const bytesCol = "t.bytes";

--- a/grafana-datasource-plugin/src/query.ts
+++ b/grafana-datasource-plugin/src/query.ts
@@ -111,6 +111,18 @@ export function validateTransformInput(raw: string): string | undefined {
     return expr === undefined ? undefined : validateExpression(expr);
 }
 
+export function transformPreview(raw: string, expand: (value: string) => string): string | undefined {
+    const expanded = expand(raw ?? '');
+    if (validateTransformInput(expanded) !== undefined) {
+        return undefined;
+    }
+    const normalized = normalizeTransform(expanded);
+    if (normalized === undefined || normalized === (raw ?? '').trim()) {
+        return undefined;
+    }
+    return normalized;
+}
+
 export function bindValueToken(expr: string, column: string): string {
     return expr.replace(VALUE_TOKEN_PATTERN, `(${column})`);
 }

--- a/grafana-datasource-plugin/src/query.ts
+++ b/grafana-datasource-plugin/src/query.ts
@@ -7,6 +7,8 @@ export const VALUE_TOKEN = '$__value';
 const VALUE_TOKEN_PATTERN = /\$__value/g;
 const NUMERIC_PATTERN = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
 const NEAR_MISS_PATTERN = /\$(v|value)\b/;
+const TRAILING_OP_PATTERN = /[-+*/%^<>=~|&]$/;
+const LEADING_OP_PATTERN = /^[*/%^<>=|&]/;
 
 
 // Resolve channel references to concrete { component, name } pairs.
@@ -70,6 +72,13 @@ export function validateExpression(expr: string): string | undefined {
             return `Unknown value token. Did you mean ${VALUE_TOKEN}?`;
         }
         return `Expression must reference ${VALUE_TOKEN} (or be a plain number).`;
+    }
+    const trimmed = expr.trim();
+    if (TRAILING_OP_PATTERN.test(trimmed)) {
+        return 'Expression cannot end with an operator.';
+    }
+    if (LEADING_OP_PATTERN.test(trimmed)) {
+        return 'Expression cannot begin with an operator.';
     }
     if (expr.includes(';')) {
         return 'Expression cannot contain ";".';

--- a/grafana-datasource-plugin/src/query.ts
+++ b/grafana-datasource-plugin/src/query.ts
@@ -1,4 +1,4 @@
-import { ChannelQuery, ChannelRef, ResolvedQuery, TransformRef } from "types";
+import { ChannelQuery, ChannelRef, MyQuery, ResolvedQuery, TransformRef } from "types";
 import { DataQueryRequest } from "@grafana/data";
 
 // token for user transforms
@@ -26,6 +26,30 @@ export function resolveChannels(
         }
         return { component: expanded, name: '' };
     });
+}
+
+// Expand all template variables in a query
+export function resolveQuery(
+    query: MyQuery,
+    replace: (value: string) => string,
+    known: ChannelRef[] = []
+): ResolvedQuery {
+    return {
+        ...query,
+        channels: resolveChannels(query.channels ?? [], replace, known),
+        sources: query.sources?.map(replace) ?? [],
+        keys: query.keys?.map((k) => ({
+            component: replace(k.component),
+            channel: replace(k.channel),
+            key: replace(k.key),
+        })) ?? [],
+        transforms: query.transforms?.map((t) => ({
+            component: replace(t.component),
+            channel: replace(t.channel),
+            targetKey: t.targetKey === undefined ? undefined : replace(t.targetKey),
+            expr: replace(t.expr),
+        })) ?? [],
+    };
 }
 
 // Handle factor shorthand / full expression cases

--- a/grafana-datasource-plugin/src/types.ts
+++ b/grafana-datasource-plugin/src/types.ts
@@ -25,6 +25,13 @@ export interface KeyRef {
   key: string;
 }
 
+export interface TransformRef {
+  component: string;
+  channel: string;
+  targetKey?: string;  // if undefined, transform applies to the whole channel
+  expr: string;
+}
+
 export interface MyQuery extends DataQuery {
   queryType: QueryType;
   channels: ChannelQuery[];
@@ -34,12 +41,13 @@ export interface MyQuery extends DataQuery {
   timeOverrideFrom?: string;
   timeOverrideTo?: string;
   aggregation: Aggregation;
+  transforms?: TransformRef[];
   rawSql?: string;
 }
 
 export type ResolvedQuery = Omit<MyQuery, 'channels'> & { channels: ChannelRef[] };
 
-export const DEFAULT_QUERY: Partial<MyQuery> = { queryType: 'telemetry', channels: [], sources: [], keys: [], timeField: 'ert', aggregation: 'avg' };
+export const DEFAULT_QUERY: Partial<MyQuery> = { queryType: 'telemetry', channels: [], sources: [], keys: [], transforms: [], timeField: 'ert', aggregation: 'avg' };
 
 export function withDefaults(query: MyQuery): MyQuery {
   return {


### PR DESCRIPTION
Adds a new "Value Transform" area to the telemetry section of the datasource plugin. This will enable you to transform columns by scalars (or use postgres expressions), supporting both scalar and multi-valued (keyed) channels.

Usage instructions have been updated, but the cell can take two input types; a scalar (or template variable which expands to a scalar), or an expression including `$__value` (something like `$v` couldn't be used because it could be confused with a variable). This PR includes validation and descriptive tooltips which also show the final transformation with all variables expanded :)

> [!NOTE]
> This does not yet include a feature to handle renaming columns as a transformation; this is probably best handled in another PR (see #206)

## Screenshots
<img width="754" height="95" alt="Screenshot 2026-08-19 at 2 32 50 PM" src="https://github.com/user-attachments/assets/98fd6154-4b34-4a80-b926-3a170786b4d4" />
<img width="806" height="131" alt="Screenshot 2026-08-19 at 2 33 43 PM" src="https://github.com/user-attachments/assets/0d3fa61e-308d-4d99-9e2d-514f4adc2d1f" />
<img width="796" height="124" alt="Screenshot 2026-08-19 at 2 34 07 PM" src="https://github.com/user-attachments/assets/c1c3b64e-23eb-4410-b649-5117a58c2aa0" />
<img width="770" height="141" alt="Screenshot 2026-08-19 at 2 34 23 PM" src="https://github.com/user-attachments/assets/c6562374-ffb6-4f33-8406-1ae613438361" />

## Issues
Closes #203 