### PR TITLE
Add Display Override to Value Transform

### DIFF
--- a/grafana-datasource-plugin/src/components/TelemetryFields.tsx
+++ b/grafana-datasource-plugin/src/components/TelemetryFields.tsx
@@ -181,7 +181,12 @@ export function TelemetryFields({ query, onChange, onRunQuery, datasource, share
       })
       .filter((ch): ch is ChannelQuery => ch !== null);
 
-    const updated: MyQuery = { ...query, channels, keys: [], sources: [], transforms: [] };
+    const stillExists = (component: string, channel: string) =>
+      channels.some((ch) => ch.raw === undefined && ch.component === component && ch.name === channel);
+    const keys = (query.keys ?? []).filter((k) => stillExists(k.component, k.channel));
+    const transforms = (query.transforms ?? []).filter((t) => stillExists(t.component, t.channel));
+
+    const updated: MyQuery = { ...query, channels, keys, transforms };
     onChange(updated);
     if (channels.length) {
       onRunQuery();

--- a/grafana-datasource-plugin/src/components/TransformFields.test.tsx
+++ b/grafana-datasource-plugin/src/components/TransformFields.test.tsx
@@ -124,3 +124,122 @@ describe('TransformFields — template variable shorthand', () => {
     );
   });
 });
+
+describe('TransformFields — display name override', () => {
+  // On a fresh query (no transforms) the section is collapsed; expand it so the
+  // per-row inputs mount, mirroring how a user reaches a name-only override.
+  const openSection = () => {
+    act(() => {
+      fireEvent.click(screen.getByTestId('query-editor-transform-section'));
+    });
+  };
+
+  it('shows the row label as the alias placeholder', () => {
+    renderFields();
+    openSection();
+    const alias = screen.getByTestId('query-editor-alias-CDH.Temperature');
+    expect(alias).toHaveAttribute('placeholder', 'CDH.Temperature');
+    expect(alias).toHaveValue('');
+  });
+
+  it('renders an existing name override in the alias field', () => {
+    renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: 'Reactor Temp' }],
+    });
+    expect(screen.getByTestId('query-editor-alias-CDH.Temperature')).toHaveValue('Reactor Temp');
+  });
+
+  it('stores a name-only override (empty expr) on change', () => {
+    const { onChange } = renderFields();
+    openSection();
+    const alias = screen.getByTestId('query-editor-alias-CDH.Temperature');
+    act(() => {
+      fireEvent.change(alias, { target: { value: 'Reactor Temp' } });
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transforms: [
+          { component: 'CDH', channel: 'Temperature', targetKey: undefined, expr: '', name: 'Reactor Temp' },
+        ],
+      })
+    );
+  });
+
+  it('preserves an existing expression when a name is added', () => {
+    const { onChange } = renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '$__value * 2' }],
+    });
+    const alias = screen.getByTestId('query-editor-alias-CDH.Temperature');
+    act(() => {
+      fireEvent.change(alias, { target: { value: 'Reactor Temp' } });
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transforms: [
+          { component: 'CDH', channel: 'Temperature', targetKey: undefined, expr: '$__value * 2', name: 'Reactor Temp' },
+        ],
+      })
+    );
+  });
+
+  it('preserves an existing name when the expression is edited', () => {
+    const { onChange } = renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: 'Reactor Temp' }],
+    });
+    const expr = screen.getByTestId('query-editor-transform-CDH.Temperature');
+    act(() => {
+      fireEvent.change(expr, { target: { value: '2' } });
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transforms: [
+          { component: 'CDH', channel: 'Temperature', targetKey: undefined, expr: '2', name: 'Reactor Temp' },
+        ],
+      })
+    );
+  });
+
+  it('drops the row when both the expression and name are cleared', () => {
+    const { onChange } = renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: 'Reactor Temp' }],
+    });
+    const alias = screen.getByTestId('query-editor-alias-CDH.Temperature');
+    act(() => {
+      fireEvent.change(alias, { target: { value: '' } });
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ transforms: [] })
+    );
+  });
+
+  it('keeps the row (drops only the name) when a name is cleared but an expression remains', () => {
+    const { onChange } = renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2', name: 'Reactor Temp' }],
+    });
+    const alias = screen.getByTestId('query-editor-alias-CDH.Temperature');
+    act(() => {
+      fireEvent.change(alias, { target: { value: '' } });
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transforms: [{ component: 'CDH', channel: 'Temperature', targetKey: undefined, expr: '2' }],
+      })
+    );
+  });
+
+  it('shows the expanded-name hint when the alias uses a template variable', () => {
+    vars = { label: 'Reactor' };
+    renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: '$label Temp' }],
+    });
+    const hint = screen.getByTestId('query-editor-alias-preview-CDH.Temperature');
+    expect(hint).toHaveAttribute('title', '= Reactor Temp');
+  });
+
+  it('shows no expanded-name hint for a literal alias', () => {
+    renderFields({
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: 'Reactor Temp' }],
+    });
+    expect(screen.queryByTestId('query-editor-alias-preview-CDH.Temperature')).not.toBeInTheDocument();
+  });
+});

--- a/grafana-datasource-plugin/src/components/TransformFields.tsx
+++ b/grafana-datasource-plugin/src/components/TransformFields.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CollapsableSection, Icon, InlineField, Input, Tooltip } from '@grafana/ui';
 import { getTemplateSrv } from '@grafana/runtime';
 import { KeyRef, MyQuery, TransformRef } from '../types';
-import { transformPreview, validateTransformInput, VALUE_TOKEN } from '../query';
+import { namePreview, transformPreview, validateTransformInput, VALUE_TOKEN } from '../query';
 
 interface TransformFieldsProps {
   query: MyQuery;
@@ -30,6 +30,16 @@ const SYNTAX_HELP = (
       <code>{`${VALUE_TOKEN} * 9.0/5.0 + 32`}</code>, <code>{`ABS(${VALUE_TOKEN})`}</code>
     </p>
     <p>Applies to numeric channels only. Boolean, string, and byte values are unaffected.</p>
+  </div>
+);
+
+const NAME_HELP = (
+  <div>
+    <p>Override the display name shown for this series in the legend and tooltips.</p>
+    <p>
+      Leave empty to use the default name. Template variables (e.g. <code>$var</code>) are
+      expanded. A panel&apos;s &quot;Display name&quot; option still takes precedence.
+    </p>
   </div>
 );
 
@@ -79,24 +89,46 @@ export function buildTransformRows(
 
 export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: TransformFieldsProps) {
   const rows = buildTransformRows(keysByChannel, query.keys ?? []);
+  const transforms = query.transforms ?? [];
+  const [isOpen, setIsOpen] = useState(transforms.length > 0);
+
   if (!rows.length) {
     return null;
   }
-
-  const transforms = query.transforms ?? [];
 
   const expand = (raw: string) => getTemplateSrv().replace(raw);
 
   const valueFor = (row: TransformRow): string =>
     transforms.find((t) => matchesRow(t, row))?.expr ?? '';
 
-  const onExprChange = (row: TransformRow, raw: string) => {
+  const nameFor = (row: TransformRow): string =>
+    transforms.find((t) => matchesRow(t, row))?.name ?? '';
+
+  // Insert/update/remove the transform for a row. A row is kept when it has a
+  // non-empty expression OR a non-empty name override, and dropped only when
+  // both are empty.
+  const upsertRow = (row: TransformRow, patch: { expr?: string; name?: string }) => {
+    const current = transforms.find((t) => matchesRow(t, row));
     const others = transforms.filter((t) => !matchesRow(t, row));
-    const next = raw.trim()
-      ? [...others, { component: row.component, channel: row.channel, targetKey: row.targetKey, expr: raw }]
+    const expr = (patch.expr ?? current?.expr ?? '');
+    const name = (patch.name ?? current?.name ?? '');
+    const next = expr.trim() || name.trim()
+      ? [
+          ...others,
+          {
+            component: row.component,
+            channel: row.channel,
+            targetKey: row.targetKey,
+            expr,
+            ...(name.trim() ? { name } : {}),
+          },
+        ]
       : others;
     onChange({ ...query, transforms: next });
   };
+
+  const onExprChange = (row: TransformRow, raw: string) => upsertRow(row, { expr: raw });
+  const onNameChange = (row: TransformRow, raw: string) => upsertRow(row, { name: raw });
 
   const runIfValid = (row: TransformRow) => {
     if (!validateTransformInput(expand(valueFor(row)))) {
@@ -107,50 +139,85 @@ export function TransformFields({ query, onChange, onRunQuery, keysByChannel }: 
   return (
     <CollapsableSection
       label="Value Transform"
-      isOpen={transforms.length > 0}
+      isOpen={isOpen}
+      onToggle={setIsOpen}
       headerDataTestId="query-editor-transform-section"
     >
       {rows.map((row, index) => {
         const raw = valueFor(row);
+        const alias = nameFor(row);
         const error = validateTransformInput(expand(raw));
         const preview = transformPreview(raw, expand);
+        const aliasPreview = namePreview(alias, expand);
         const inputId = `query-editor-transform-${index}`;
         return (
-          <InlineField
-            key={row.id}
-            label={row.label}
-            tooltip={SYNTAX_HELP}
-            interactive
-            invalid={!!error}
-            error={error}
-            grow
-            shrink
-          >
-            <Input
-              id={inputId}
-              data-testid={`query-editor-transform-${row.label}`}
-              value={raw}
-              placeholder={VALUE_TOKEN}
+          <React.Fragment key={row.id}>
+            <InlineField
+              label={row.label}
+              tooltip={SYNTAX_HELP}
+              interactive
               invalid={!!error}
-              prefix={<Icon name="calculator-alt" />}
-              suffix={
-                preview ? (
-                  <Tooltip content={`= ${preview}`}>
-                    <span data-testid={`query-editor-transform-preview-${row.label}`} title={`= ${preview}`}>
-                      <Icon name="info-circle" />
-                    </span>
-                  </Tooltip>
-                ) : undefined
-              }
-              onChange={(e) => onExprChange(row, e.currentTarget.value)}
-              onBlur={() => runIfValid(row)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  runIfValid(row);
+              error={error}
+              grow
+              shrink
+            >
+              <Input
+                id={inputId}
+                data-testid={`query-editor-transform-${row.label}`}
+                value={raw}
+                placeholder={VALUE_TOKEN}
+                invalid={!!error}
+                prefix={<Icon name="calculator-alt" />}
+                suffix={
+                  preview ? (
+                    <Tooltip content={`= ${preview}`}>
+                      <span data-testid={`query-editor-transform-preview-${row.label}`} title={`= ${preview}`}>
+                        <Icon name="info-circle" />
+                      </span>
+                    </Tooltip>
+                  ) : undefined
                 }
-              }}
-            />
-          </InlineField>
+                onChange={(e) => onExprChange(row, e.currentTarget.value)}
+                onBlur={() => runIfValid(row)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    runIfValid(row);
+                  }
+                }}
+              />
+            </InlineField>
+            <InlineField
+              label="Display name"
+              tooltip={NAME_HELP}
+              interactive
+              grow
+              shrink
+            >
+              <Input
+                id={`query-editor-alias-${index}`}
+                data-testid={`query-editor-alias-${row.label}`}
+                value={alias}
+                placeholder={row.label}
+                prefix={<Icon name="pen" />}
+                suffix={
+                  aliasPreview ? (
+                    <Tooltip content={`= ${aliasPreview}`}>
+                      <span data-testid={`query-editor-alias-preview-${row.label}`} title={`= ${aliasPreview}`}>
+                        <Icon name="info-circle" />
+                      </span>
+                    </Tooltip>
+                  ) : undefined
+                }
+                onChange={(e) => onNameChange(row, e.currentTarget.value)}
+                onBlur={() => runIfValid(row)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    runIfValid(row);
+                  }
+                }}
+              />
+            </InlineField>
+          </React.Fragment>
         );
       })}
     </CollapsableSection>

--- a/grafana-datasource-plugin/src/datasource.ts
+++ b/grafana-datasource-plugin/src/datasource.ts
@@ -3,7 +3,7 @@ import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { from } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { MyQuery, MyDataSourceOptions, DEFAULT_QUERY, ChannelQuery, ChannelRef, KeyRef, ResolvedQuery, withDefaults } from './types';
-import { buildQuery, resolveChannels, resolveQuery } from 'query';
+import { aliasForLabels, buildQuery, resolveChannels, resolveQuery } from 'query';
 
 export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptions> {
   private knownChannels?: Promise<ChannelRef[]>;
@@ -44,6 +44,9 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
           const query = request.targets.find((t) => t.refId === result.refId);
           if (query?.queryType === 'events' && query.sources?.length) {
             result.fields = result.fields.filter((f: { name: string }) => f.name !== 'source');
+          }
+          if (query?.queryType === 'telemetry' && query.transforms?.some((t) => t.name)) {
+            applySeriesAliases(result, query as ResolvedQuery);
           }
         }
         return response;
@@ -95,4 +98,22 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
     return this.getResource('events/sources');
   }
 
+}
+
+// Handle value transform overrides to the datasource "auto name"; purposefully loses to panel override
+function applySeriesAliases(frame: { fields: any[] }, query: ResolvedQuery): void {
+  for (const field of frame.fields) {
+    const labels = field.labels as Record<string, string> | undefined;
+    if (!labels) {
+      continue;
+    }
+    const alias = aliasForLabels(query, {
+      component: labels.component,
+      channel: labels.channel,
+      key: labels.key,
+    });
+    if (alias) {
+      field.config = { ...(field.config ?? {}), displayNameFromDS: alias };
+    }
+  }
 }

--- a/grafana-datasource-plugin/src/query.test.ts
+++ b/grafana-datasource-plugin/src/query.test.ts
@@ -1,9 +1,12 @@
 import {
+  aliasForLabels,
   bindValueToken,
   buildTelemetryQuery,
   buildTransformCase,
+  namePreview,
   normalizeTransform,
   resolveChannels,
+  resolveQuery,
   transformPreview,
   validateExpression,
   validateTransformInput,
@@ -527,5 +530,124 @@ describe('value token vs. Grafana template expansion', () => {
   it('routes a variable that resolves to a bare number through the shorthand path', () => {
     const replace = replaceWith({ gain: '0.5' });
     expect(normalizeTransform(replace('$gain'))).toBe('$__value * 0.5');
+  });
+});
+
+describe('aliasForLabels', () => {
+  const labels = (key = 'value') => ({ component: 'CDH', channel: 'Temperature', key });
+
+  it('returns the name for a matching whole-channel transform', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: 'Reactor Temp' }],
+    });
+    expect(aliasForLabels(q, labels())).toBe('Reactor Temp');
+  });
+
+  it('returns undefined when the channel is not selected', () => {
+    const q = baseQuery({
+      channels: [{ component: 'Other', name: 'Thing' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: 'Reactor Temp' }],
+    });
+    expect(aliasForLabels(q, labels())).toBeUndefined();
+  });
+
+  it('returns undefined when no transform carries a name', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2' }],
+    });
+    expect(aliasForLabels(q, labels())).toBeUndefined();
+  });
+
+  it('treats a whitespace-only name as no override', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: '   ' }],
+    });
+    expect(aliasForLabels(q, labels())).toBeUndefined();
+  });
+
+  it('matches a key-specific override only on the matching key', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', targetKey: 'value.x', expr: '', name: 'X axis' }],
+    });
+    expect(aliasForLabels(q, labels('value.x'))).toBe('X axis');
+    expect(aliasForLabels(q, labels('value.y'))).toBeUndefined();
+  });
+
+  it('prefers a key-specific override over a channel-wide one', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [
+        { component: 'CDH', channel: 'Temperature', expr: '', name: 'Whole channel' },
+        { component: 'CDH', channel: 'Temperature', targetKey: 'value.x', expr: '', name: 'X axis' },
+      ],
+    });
+    expect(aliasForLabels(q, labels('value.x'))).toBe('X axis');
+    expect(aliasForLabels(q, labels('value.y'))).toBe('Whole channel');
+  });
+
+  it('trims surrounding whitespace from the name', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: '  Reactor Temp  ' }],
+    });
+    expect(aliasForLabels(q, labels())).toBe('Reactor Temp');
+  });
+});
+
+describe('namePreview', () => {
+  const replaceWith = (vars: Record<string, string>) => (value: string) =>
+    value.replace(/\$\w+/g, (m) => (m.slice(1) in vars ? vars[m.slice(1)] : m));
+
+  it('shows the expanded name when a template variable resolves', () => {
+    expect(namePreview('$label Temp', replaceWith({ label: 'Reactor' }))).toBe('Reactor Temp');
+  });
+
+  it('returns undefined for a literal name with no variables', () => {
+    expect(namePreview('Reactor Temp', replaceWith({}))).toBeUndefined();
+  });
+
+  it('returns undefined when a variable does not resolve (text unchanged)', () => {
+    expect(namePreview('$missing Temp', replaceWith({}))).toBeUndefined();
+  });
+
+  it('returns undefined for an empty name', () => {
+    expect(namePreview('', replaceWith({ label: 'Reactor' }))).toBeUndefined();
+  });
+});
+
+describe('name-only transforms', () => {
+  const replaceWith = (vars: Record<string, string>) => (value: string) =>
+    value.replace(/\$\w+/g, (m) => (m.slice(1) in vars ? vars[m.slice(1)] : m));
+
+  it('resolveQuery expands template variables in the name', () => {
+    const resolved = resolveQuery(
+      baseQuery({
+        channels: [{ component: 'CDH', name: 'Temperature' }],
+        transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: '$label Temp' }],
+      }) as MyQuery,
+      replaceWith({ label: 'Reactor' })
+    );
+    expect(resolved.transforms?.[0].name).toBe('Reactor Temp');
+  });
+
+  it('emits no CASE/SQL for a name-only transform', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '', name: 'Reactor Temp' }],
+    });
+    expect(buildTransformCase(q, 't.floating::double precision')).toBe('t.floating::double precision');
+    expect(buildTelemetryQuery(q, FROM, TO)).not.toContain('CASE');
+  });
+
+  it('still emits SQL when both an expression and a name are set', () => {
+    const q = baseQuery({
+      channels: [{ component: 'CDH', name: 'Temperature' }],
+      transforms: [{ component: 'CDH', channel: 'Temperature', expr: '2', name: 'Reactor Temp' }],
+    });
+    expect(buildTelemetryQuery(q, FROM, TO)).toContain('THEN (t.floating::double precision) * 2');
   });
 });

--- a/grafana-datasource-plugin/src/query.ts
+++ b/grafana-datasource-plugin/src/query.ts
@@ -50,6 +50,7 @@ export function resolveQuery(
             channel: replace(t.channel),
             targetKey: t.targetKey === undefined ? undefined : replace(t.targetKey),
             expr: replace(t.expr),
+            name: t.name === undefined ? undefined : replace(t.name),
         })) ?? [],
     };
 }
@@ -123,6 +124,17 @@ export function transformPreview(raw: string, expand: (value: string) => string)
     return normalized;
 }
 
+// Preview the template-expanded display name, but only when expansion actually
+// changed the text (i.e. a template variable resolved to something).
+export function namePreview(raw: string, expand: (value: string) => string): string | undefined {
+    const trimmed = (raw ?? '').trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    const expanded = expand(raw).trim();
+    return expanded && expanded !== trimmed ? expanded : undefined;
+}
+
 export function bindValueToken(expr: string, column: string): string {
     return expr.replace(VALUE_TOKEN_PATTERN, `(${column})`);
 }
@@ -154,6 +166,36 @@ export function buildTransformCase(q: ResolvedQuery, column: string): string {
         return `WHEN ${conditions.join(' AND ')} THEN ${bindValueToken(expr, column)}`;
     });
     return `CASE ${branches.join(' ')} ELSE ${column} END`;
+}
+
+// Resolve the display-name override for a series identified by its labels, or
+// undefined when no matching transform carries a (non-empty) name. Matching
+// mirrors applicableTransforms: only transforms on a selected channel apply,
+// and a key-specific override wins over a channel-wide one.
+export function aliasForLabels(
+    q: ResolvedQuery,
+    labels: { component: string; channel: string; key: string }
+): string | undefined {
+    const channels = q.channels ?? [];
+    const onSelectedChannel = channels.some(
+        (ch) => ch.component === labels.component && ch.name === labels.channel
+    );
+    if (!onSelectedChannel) {
+        return undefined;
+    }
+
+    const candidates = (q.transforms ?? []).filter(
+        (t) =>
+            t.component === labels.component &&
+            t.channel === labels.channel &&
+            (t.name ?? '').trim() !== '' &&
+            (t.targetKey === undefined || t.targetKey === labels.key)
+    );
+    // Prefer a key-specific override over a channel-wide one.
+    const match =
+        candidates.find((t) => t.targetKey !== undefined) ??
+        candidates.find((t) => t.targetKey === undefined);
+    return match ? match.name!.trim() : undefined;
 }
 
 export function buildQuery(q: ResolvedQuery, options: DataQueryRequest): string {

--- a/grafana-datasource-plugin/src/types.ts
+++ b/grafana-datasource-plugin/src/types.ts
@@ -29,7 +29,8 @@ export interface TransformRef {
   component: string;
   channel: string;
   targetKey?: string;  // if undefined, transform applies to the whole channel
-  expr: string;
+  expr: string;        // value expression; may be '' when only a name override is set
+  name?: string;       // display-name override for the series (literal text)
 }
 
 export interface MyQuery extends DataQuery {


### PR DESCRIPTION
Adds display name override input sections in the value transform area to allow the user to override the series name. This will "beat out" the name returned from the datasource backend (auto-generated) but will lose (purposefully) to panel-based overrides since those have the final say.

These overrides also allow for template variables to be used! There's an informational tooltip analogous to the one for values that shows what the final expanded name will be within the input box :)

This PR satisfies the open-ended issue mentioned in #205.

## Screenshots
<img width="782" height="705" alt="Screenshot 2026-08-19 at 3 48 42 PM" src="https://github.com/user-attachments/assets/3c019eef-aa44-4e8e-908a-d27d28856d14" />

## Issues
Closes #206 

