### PR TITLE
Fix signed 64-bit dictionary fields being treated as unsigned

### DIFF
--- a/src/modules/types/src/conversion.ts
+++ b/src/modules/types/src/conversion.ts
@@ -64,7 +64,7 @@ export function integerKindFromProto(kind: Proto.IntKind): Def.IntegerTypeKind {
         case Proto.IntKind.INT_U64:
             return Def.TypeKind.u64;
         case Proto.IntKind.INT_I64:
-            return Def.TypeKind.u64;
+            return Def.TypeKind.i64;
     }
 }
 

--- a/src/modules/types/test/conversion.test.ts
+++ b/src/modules/types/test/conversion.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { ConversionContext, valueFromProto } from '../src/conversion';
+import {
+    ConversionContext,
+    typeFromProto,
+    typeToProto,
+    valueFromProto,
+} from '../src/conversion';
+import { TypeKind } from '../src/def';
 import { hermes as Proto } from '../src/proto';
 
 type NumericValue = number | bigint;
@@ -230,4 +236,23 @@ test('rejects an unknown numeric kind', () => {
         kind: 999 as Proto.NumberKind,
         value: Uint8Array.from([0]),
     })).toThrow('value: invalid value');
+});
+
+test.each([
+    { name: 'INT_U8', protoKind: Proto.IntKind.INT_U8, typeKind: TypeKind.u8 },
+    { name: 'INT_I8', protoKind: Proto.IntKind.INT_I8, typeKind: TypeKind.i8 },
+    { name: 'INT_U16', protoKind: Proto.IntKind.INT_U16, typeKind: TypeKind.u16 },
+    { name: 'INT_I16', protoKind: Proto.IntKind.INT_I16, typeKind: TypeKind.i16 },
+    { name: 'INT_U32', protoKind: Proto.IntKind.INT_U32, typeKind: TypeKind.u32 },
+    { name: 'INT_I32', protoKind: Proto.IntKind.INT_I32, typeKind: TypeKind.i32 },
+    { name: 'INT_U64', protoKind: Proto.IntKind.INT_U64, typeKind: TypeKind.u64 },
+    { name: 'INT_I64', protoKind: Proto.IntKind.INT_I64, typeKind: TypeKind.i64 },
+])('$name round-trips', ({ protoKind, typeKind }) => {
+    const type = typeFromProto(
+        { int: { kind: protoKind } },
+        new ConversionContext(['type']),
+    );
+
+    expect(type.kind).toBe(typeKind);
+    expect(typeToProto(type).int?.kind).toBe(protoKind);
 });


### PR DESCRIPTION
Fixes #211 

## Summary

Hermes incorrectly converted the protobuf `INT_I64` dictionary type into the internal unsigned `u64` type.

As a result, signed 64-bit command arguments appeared as `U64` in the sequence editor, and valid negative values were rejected.

## What changed

Map protobuf `INT_I64` fields to Hermes `TypeKind.i64`.

## Result

A sequence command such as:

```text
R00:00:00 Repro.SET_SIGNED_64 -1
```

is now recognized as having an `I64` argument, and `-1` is accepted as a valid value.