### PR TITLE
Fix telemetry time-window culling

### DIFF
--- a/src/extensions/core/app/telemetry/plot.tsx
+++ b/src/extensions/core/app/telemetry/plot.tsx
@@ -2,6 +2,7 @@ import React, {
     useCallback,
     useState,
     useEffect,
+    useEffectEvent,
     useRef,
     useMemo,
 } from 'react';
@@ -10,6 +11,7 @@ import uPlot from 'uplot';
 
 import { getMessages, vscode } from '@gov.nasa.jpl.hermes/vscode/browser';
 import type { BackendPlotMessage, FrontendPlotMessage, TelemetrySeries, TelemetrySeriesData } from '../../common/telemetry';
+import { cullTelemetrySeriesData, cullTelemetrySeriesMap } from '../../common/telemetryTimeWindow';
 
 import { UPlotChart, UPlotConfigBuilder, AxisPlacement, type ScaleProps, ScaleDirection, ScaleOrientation, LineInterpolation } from './uplot';
 import { VizLegendTable, VizLegendItem } from './VizLegend';
@@ -95,7 +97,6 @@ function TelemetryPlot() {
     const [plotData, setPlotData] = useState<Record<string, TelemetrySeriesData>>({});
     const [plotDimensions, setPlotDimensions] = useState({ width: 800, height: 400 });
 
-    const [tick, setTick] = useState(0); // Force periodic rerenders
     // const [hoveredSeries, setHoveredSeries] = useState<string | null>(null);
     const [disabledSeries, setDisabledSeries] = useState<Set<string>>(new Set());
 
@@ -128,7 +129,7 @@ function TelemetryPlot() {
     const handleMessages = useCallback((msg: BackendPlotMessage) => {
         switch (msg.type) {
             case 'full': {
-                // Replace all data with new full dataset
+                // Replace plot data with the full time-windowed dataset from the host.
                 setPlotData(msg.data);
                 setPlotInfo(msg.info);
                 break;
@@ -160,24 +161,9 @@ function TelemetryPlot() {
                         };
 
                         // Cull points outside the time window
-                        if (timeWindow !== Infinity) {
-                            const startIdx = combinedData.time.findIndex(t => t >= cutoffTime);
-                            if (startIdx > 0) {
-                                combinedData.time = combinedData.time.slice(startIdx);
-                                combinedData.sclk = combinedData.sclk.slice(startIdx);
-                                if (combinedData.valueStr) {
-                                    combinedData.valueStr = combinedData.valueStr.slice(startIdx);
-                                }
-                                if (combinedData.valueNum) {
-                                    combinedData.valueNum = combinedData.valueNum.slice(startIdx);
-                                }
-                            }
-                        }
-
-                        next[channelKey] = {
-                            ...next[channelKey],
-                            ...combinedData,
-                        };
+                        next[channelKey] = timeWindow === Infinity
+                            ? combinedData
+                            : cullTelemetrySeriesData(combinedData, cutoffTime);
                     }
                     return next;
                 });
@@ -192,7 +178,6 @@ function TelemetryPlot() {
     }, [handleMessages]);
 
     // Build uPlot data (separate from config)
-    // Depends on tick to force rerender even when no new data arrives
     // Must iterate in same order as series in plotConfig
     const data = useMemo<uPlot.AlignedData>(() => {
         // Filter out disabled series, using plotInfo order to match series config
@@ -252,6 +237,12 @@ function TelemetryPlot() {
             u.over.addEventListener('mouseleave', () => {
                 setTooltipVisible(false);
             });
+        });
+
+        builder.addHook('destroy', (u) => {
+            if (uPlotInstanceRef.current === u) {
+                uPlotInstanceRef.current = null;
+            }
         });
 
         builder.addHook('setLegend', (u) => {
@@ -329,19 +320,32 @@ function TelemetryPlot() {
         return builder;
     }, [plotInfo, interpolationMode, disabledSeries, timeWindow]);
 
-    // Periodic rerender to keep time axis relative to wall clock
+    const onClockTick = useEffectEvent(() => {
+        if (timeWindow === Infinity) {
+            return;
+        }
+
+        const now = Date.now();
+        const cutoffTime = now - timeWindow;
+
+        // Advance the uPlot canvas without rerendering the React component.
+        uPlotInstanceRef.current?.setScale('x', {
+            min: cutoffTime,
+            max: now,
+        });
+
+        // Returning the same map when nothing expires lets React skip rerendering.
+        setPlotData(prev => cullTelemetrySeriesMap(prev, cutoffTime));
+    });
+
+    // Keep the finite time window synchronized with the wall clock.
     useEffect(() => {
-        // Update every second to keep the time axis moving
         const interval = setInterval(() => {
-            setTick(t => t + 1);
+            onClockTick();
         }, 100);
 
         return () => clearInterval(interval);
     }, []);
-
-    const realtimeData = useMemo<uPlot.AlignedData>(
-        () => [...data], [data, tick]
-    );
 
     // Handle resize and measure container using ResizeObserver
     useEffect(() => {
@@ -542,7 +546,7 @@ function TelemetryPlot() {
                 ) : (
                     <div className="plot-container">
                         <UPlotChart
-                            data={realtimeData}
+                            data={data}
                             config={plotConfig}
                             width={plotDimensions.width}
                             height={plotDimensions.height}

--- a/src/extensions/core/common/telemetryTimeWindow.ts
+++ b/src/extensions/core/common/telemetryTimeWindow.ts
@@ -1,0 +1,59 @@
+import type { TelemetrySeriesData } from './telemetry';
+
+/**
+ * Get the slice index for retaining samples within a time window.
+ *
+ * Returns the index of the first timestamp on or after the cutoff. When every
+ * sample is expired, returns `times.length` so `times.slice(startIdx)` would
+ * properly result in an empty array.
+ */
+export function getTimeWindowSliceIndex(times: readonly number[], cutoffTime: number): number {
+    const startIdx = times.findIndex(time => time >= cutoffTime);
+    return startIdx === -1 ? times.length : startIdx;
+}
+
+/**
+ * Return telemetry data with samples before the cutoff removed from every
+ * column. Returns the original data when no samples have expired.
+ */
+export function cullTelemetrySeriesData(
+    data: TelemetrySeriesData,
+    cutoffTime: number,
+): TelemetrySeriesData {
+    const startIdx = getTimeWindowSliceIndex(data.time, cutoffTime);
+    if (startIdx === 0) {
+        return data;
+    }
+
+    return {
+        time: data.time.slice(startIdx),
+        sclk: data.sclk.slice(startIdx),
+        valueStr: data.valueStr?.slice(startIdx),
+        valueNum: data.valueNum?.slice(startIdx),
+    };
+}
+
+/**
+ * Cull expired samples from every telemetry series. Returns the original map
+ * when no series changes so React can avoid an unnecessary state update.
+ */
+export function cullTelemetrySeriesMap(
+    data: Record<string, TelemetrySeriesData>,
+    cutoffTime: number,
+): Record<string, TelemetrySeriesData> {
+    let next = data;
+
+    for (const [channelKey, channelData] of Object.entries(data)) {
+        const culledData = cullTelemetrySeriesData(channelData, cutoffTime);
+        if (culledData === channelData) {
+            continue;
+        }
+
+        if (next === data) {
+            next = { ...data };
+        }
+        next[channelKey] = culledData;
+    }
+
+    return next;
+}

--- a/src/extensions/core/src/components/TelemetryViewer.ts
+++ b/src/extensions/core/src/components/TelemetryViewer.ts
@@ -6,6 +6,7 @@ import { Api } from '@gov.nasa.jpl.hermes/api';
 import { WebViewMessenger, WebViewPanelBase } from '@gov.nasa.jpl.hermes/vscode';
 
 import { FrontendTableMessage, BackendTableMessage, FrontendPlotMessage, BackendPlotMessage, TelemetrySeries, TelemetrySeriesData, TableState } from '../../common/telemetry';
+import { cullTelemetrySeriesData } from '../../common/telemetryTimeWindow';
 import { DebounceEmitter } from '../utils/DebounceEmitter';
 
 const MAX_POINTS_PER_CHANNEL = 10000; // ~10 minutes at 10Hz
@@ -351,25 +352,10 @@ export class TelemetryPlotPanel extends WebViewPanelBase implements vscode.Webvi
                 continue;
             }
 
-            // Find the first index within the time window
-            let startIdx = 0;
-            if (cutoffTime > 0) {
-                for (let i = 0; i < data.time.length; i++) {
-                    if (data.time[i] >= cutoffTime) {
-                        startIdx = i;
-                        break;
-                    }
-                }
-            }
-
-            // Slice the arrays from startIdx to end
             fullInfo[channelKey] = series;
-            fullData[channelKey] = {
-                time: data.time.slice(startIdx),
-                sclk: data.sclk.slice(startIdx),
-                valueStr: data.valueStr?.slice(startIdx),
-                valueNum: data.valueNum?.slice(startIdx)
-            };
+            fullData[channelKey] = cutoffTime > 0
+                ? cullTelemetrySeriesData(data, cutoffTime)
+                : data;
         }
 
         messenger.postMessage({

--- a/src/extensions/core/test/telemetryTimeWindow.test.ts
+++ b/src/extensions/core/test/telemetryTimeWindow.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    cullTelemetrySeriesData,
+    cullTelemetrySeriesMap,
+    getTimeWindowSliceIndex,
+} from '../common/telemetryTimeWindow';
+
+describe('getTimeWindowSliceIndex', () => {
+    test('returns the array length when every point is expired', () => {
+        expect(getTimeWindowSliceIndex([100, 200, 300], 400)).toBe(3);
+    });
+
+    test('returns the first point on or after the cutoff', () => {
+        expect(getTimeWindowSliceIndex([100, 200, 300, 400], 300)).toBe(2);
+    });
+
+    test('retains every point when none are expired', () => {
+        expect(getTimeWindowSliceIndex([100, 200, 300], 100)).toBe(0);
+    });
+
+    test('handles an empty series', () => {
+        expect(getTimeWindowSliceIndex([], 100)).toBe(0);
+    });
+});
+
+describe('cullTelemetrySeriesData', () => {
+    const data = {
+        time: [100, 200, 300],
+        sclk: [1, 2, 3],
+        valueStr: ['10', '20', '30'],
+        valueNum: [10, 20, 30],
+    };
+
+    test('slices every column at the time-window boundary', () => {
+        expect(cullTelemetrySeriesData(data, 250)).toEqual({
+            time: [300],
+            sclk: [3],
+            valueStr: ['30'],
+            valueNum: [30],
+        });
+    });
+
+    test('removes every column when all samples are expired', () => {
+        expect(cullTelemetrySeriesData(data, 400)).toEqual({
+            time: [],
+            sclk: [],
+            valueStr: [],
+            valueNum: [],
+        });
+    });
+
+    test('returns the original data when no samples are expired', () => {
+        expect(cullTelemetrySeriesData(data, 100)).toBe(data);
+    });
+});
+
+describe('cullTelemetrySeriesMap', () => {
+    const expiredData = {
+        time: [100, 200],
+        sclk: [1, 2],
+        valueStr: ['10', '20'],
+        valueNum: [10, 20],
+    };
+    const currentData = {
+        time: [300, 400],
+        sclk: [3, 4],
+        valueStr: ['30', '40'],
+        valueNum: [30, 40],
+    };
+
+    test('culls expired series while preserving unchanged series', () => {
+        const data = {
+            expired: expiredData,
+            current: currentData,
+        };
+
+        const result = cullTelemetrySeriesMap(data, 250);
+
+        expect(result).not.toBe(data);
+        expect(result.expired).toEqual({
+            time: [],
+            sclk: [],
+            valueStr: [],
+            valueNum: [],
+        });
+        expect(result.current).toBe(currentData);
+    });
+
+    test('returns the original map when no samples are expired', () => {
+        const data = { current: currentData };
+        expect(cullTelemetrySeriesMap(data, 250)).toBe(data);
+    });
+
+    test('removes samples as the wall-clock cutoff advances', () => {
+        const data = { current: currentData };
+        expect(cullTelemetrySeriesMap(data, 500).current).toEqual({
+            time: [],
+            sclk: [],
+            valueStr: [],
+            valueNum: [],
+        });
+    });
+});


### PR DESCRIPTION
Fixes #216 

## Summary

Fix telemetry plots so data is removed after it expires from the selected time window, even when no new telemetry arrives.

Previously, the plot could retain every expired sample when there was no newer sample to use as a slice boundary. The points moved off the visible chart, but their Min, Max, and Last values remained in the legend.

## What changed

- Correctly return an empty telemetry series when every sample is expired.
- Apply the same time-window culling behavior to full datasets and appended telemetry.
- Periodically remove expired cached telemetry while the time window advances.
- Advance the chart's time axis directly without forcing the entire React component to rerender every 100 milliseconds.
- Keep telemetry columns such as time, SCLK, string values, and numeric values aligned when samples are removed.
- Add focused tests for empty data, partially expired data, fully expired data, synchronized columns, and unchanged-data reuse.

## User impact

When a telemetry channel stops receiving data, its old values now disappear after they leave the selected time window. Users will no longer see stale Min, Max, or Last values that appear to belong to the current window.

The chart's time axis continues moving normally while avoiding unnecessary React rerenders when there is no data to remove.

## Line continuity at the start of the time window

This change strictly removes every point older than the selected time window. It does not retain the final point immediately before the window as drawing context.

Retaining that previous point would allow the chart to draw a line from outside the visible area to the first point inside the window. Without it, the line starts at the first point within the selected window. This can make the left edge of the chart look less continuous, particularly when telemetry arrives infrequently or when stepped interpolation is used.

Supporting that behavior would require distinguishing between:

- Data that is actually inside the selected time window.
- An older point retained only to draw the line across the left edge.

The older point must not affect Min, Max, Last, tooltips, or whether the window is considered to contain data. It must also be removed when there is no in-window point to connect to. Keeping those two categories separate would add state and culling complexity in both the extension host and the plot.

This PR favors strict and predictable time-window behavior. If continuous lines at the left edge are the preferred user experience, support for a rendering-only previous point can be added separately.