### PR TITLE
Fix OTEL Provider / Hermes Datasource Source Distinguishing Issues

### DIFF
--- a/grafana-datasource-plugin/pkg/plugin/resources.go
+++ b/grafana-datasource-plugin/pkg/plugin/resources.go
@@ -71,7 +71,7 @@ func (d *Datasource) handleGetTelemetryChannels(w http.ResponseWriter, r *http.R
 }
 
 func (d *Datasource) handleGetTelemetrySources(w http.ResponseWriter, r *http.Request) {
-	rows, err := d.db.QueryContext(r.Context(), "SELECT DISTINCT source FROM telemetry WHERE time >= NOW() - INTERVAL '24 hours' LIMIT 100;")
+	rows, err := d.db.QueryContext(r.Context(), "SELECT DISTINCT source FROM telemetry ORDER BY source;")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -130,7 +130,7 @@ func (d *Datasource) handleGetTelemetryKeys(w http.ResponseWriter, r *http.Reque
 }
 
 func (d *Datasource) handleGetEventSources(w http.ResponseWriter, r *http.Request) {
-	rows, err := d.db.QueryContext(r.Context(), "SELECT DISTINCT source FROM events WHERE time >= NOW() - INTERVAL '24 hours' LIMIT 100;")
+	rows, err := d.db.QueryContext(r.Context(), "SELECT DISTINCT source FROM events ORDER BY source;")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -3,6 +3,8 @@ package otel
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"sync"
 	"time"
 
 	_ "embed"
@@ -46,6 +48,133 @@ func (p Params) TelemetryEnabled() bool {
 	return p.Telemetry == nil || *p.Telemetry
 }
 
+type resourceCache struct {
+	mu       sync.Mutex
+	fallback string
+	entries  map[string]*resource.Resource
+}
+
+func newResourceCache(fallback string) *resourceCache {
+	if fallback == "" {
+		fallback = "hermes"
+	}
+
+	return &resourceCache{
+		fallback: fallback,
+		entries:  map[string]*resource.Resource{},
+	}
+}
+
+func (c *resourceCache) resolveServiceName(source string) string {
+	if source == "" {
+		return c.fallback
+	}
+	return source
+}
+
+func (c *resourceCache) get(ctx context.Context, source string) (*resource.Resource, error) {
+	name := c.resolveServiceName(source)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if res, ok := c.entries[name]; ok {
+		return res, nil
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithAttributes(semconv.ServiceNameKey.String(name)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTEL resource for source %q: %w", name, err)
+	}
+
+	c.entries[name] = res
+	return res, nil
+}
+
+type sharedLogExporter struct {
+	log.Exporter
+}
+
+func (sharedLogExporter) Shutdown(context.Context) error { return nil }
+
+type logTarget struct {
+	provider *log.LoggerProvider
+	handler  slog.Handler
+}
+
+type logRouter struct {
+	mu        sync.Mutex
+	resources *resourceCache
+	exporter  log.Exporter
+	targets   map[string]*logTarget
+}
+
+func newLogRouter(resources *resourceCache, exporter log.Exporter) *logRouter {
+	return &logRouter{
+		resources: resources,
+		exporter:  sharedLogExporter{exporter},
+		targets:   map[string]*logTarget{},
+	}
+}
+
+func (r *logRouter) target(ctx context.Context, source string) (*logTarget, error) {
+	name := r.resources.resolveServiceName(source)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if target, ok := r.targets[name]; ok {
+		return target, nil
+	}
+
+	res, err := r.resources.get(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+
+	provider := log.NewLoggerProvider(
+		log.WithResource(res),
+		log.WithProcessor(log.NewBatchProcessor(r.exporter)),
+	)
+
+	target := &logTarget{
+		provider: provider,
+		handler: otelslog.NewHandler("hermes",
+			otelslog.WithLoggerProvider(provider),
+		),
+	}
+
+	r.targets[name] = target
+	return target, nil
+}
+
+func (r *logRouter) handle(ctx context.Context, source string, rec slog.Record) error {
+	target, err := r.target(ctx, source)
+	if err != nil {
+		return err
+	}
+
+	return target.handler.Handle(ctx, rec)
+}
+
+func (r *logRouter) shutdown(ctx context.Context) {
+	r.mu.Lock()
+	targets := r.targets
+	r.targets = map[string]*logTarget{}
+	r.mu.Unlock()
+
+	for _, target := range targets {
+		_ = target.provider.Shutdown(ctx)
+	}
+}
+
+type metricChunk struct {
+	source  string
+	metrics []metricdata.Metrics
+}
+
 type otelProvider struct{}
 
 func (o *otelProvider) Default() Params {
@@ -66,12 +195,7 @@ func (o *otelProvider) Start(
 
 	session.Log().Info("connecting to OTEL collector", "endpoint", settings.Endpoint)
 
-	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceNameKey.String(settings.ServiceName)),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create OTEL resource: %w", err)
-	}
+	resources := newResourceCache(settings.ServiceName)
 
 	if settings.EventsEnabled() {
 		session.Log().Info("exporting events to OTEL collector")
@@ -87,18 +211,14 @@ func (o *otelProvider) Start(
 		}
 		defer logExporter.Shutdown(context.Background())
 
-		logProvider := log.NewLoggerProvider(
-			log.WithResource(res),
-			log.WithProcessor(log.NewBatchProcessor(logExporter)),
-		)
-		defer logProvider.Shutdown(context.Background())
-
-		handler := otelslog.NewHandler("hermes",
-			otelslog.WithLoggerProvider(logProvider),
-		)
+		router := newLogRouter(resources, logExporter)
+		defer router.shutdown(context.Background())
 
 		host.Event.On(ctx, func(msg *pb.SourcedEvent) {
-			handler.Handle(context.Background(), msg.GetEvent().Record())
+			err := router.handle(context.Background(), msg.GetSource(), msg.GetEvent().Record())
+			if err != nil {
+				session.Log().Error("failed to export event", "source", msg.GetSource(), "err", err)
+			}
 		})
 	} else {
 		session.Log().Info("event logging to OTEL collector is disabled by profile settings")
@@ -118,32 +238,40 @@ func (o *otelProvider) Start(
 		}
 		defer metricExporter.Shutdown(context.Background())
 
-		cache := make(chan []metricdata.Metrics, 64)
+		cache := make(chan metricChunk, 64)
 
 		go func() {
 			ticker := time.NewTicker(1 * time.Second)
 			defer ticker.Stop()
-			var buf []metricdata.Metrics
+			buf := map[string][]metricdata.Metrics{}
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				case chunk := <-cache:
-					buf = append(buf, chunk...)
+					buf[chunk.source] = append(buf[chunk.source], chunk.metrics...)
 				case <-ticker.C:
 					if len(buf) == 0 {
 						continue
 					}
-					exportErr := metricExporter.Export(ctx, &metricdata.ResourceMetrics{
-						Resource: res,
-						ScopeMetrics: []metricdata.ScopeMetrics{{
-							Metrics: buf,
-						}},
-					})
-					if exportErr != nil {
-						session.Log().Error("failed to export telemetry metrics", "err", exportErr)
+					for source, metrics := range buf {
+						res, resErr := resources.get(ctx, source)
+						if resErr != nil {
+							session.Log().Error("failed to resolve telemetry resource", "source", source, "err", resErr)
+							continue
+						}
+
+						exportErr := metricExporter.Export(ctx, &metricdata.ResourceMetrics{
+							Resource: res,
+							ScopeMetrics: []metricdata.ScopeMetrics{{
+								Metrics: metrics,
+							}},
+						})
+						if exportErr != nil {
+							session.Log().Error("failed to export telemetry metrics", "source", source, "err", exportErr)
+						}
 					}
-					buf = nil
+					buf = map[string][]metricdata.Metrics{}
 				}
 			}
 		}()
@@ -151,7 +279,7 @@ func (o *otelProvider) Start(
 		host.Telemetry.On(ctx, func(msg *pb.SourcedTelemetry) {
 			m := msg.GetTelemetry().AsOtelMetric([]metricdata.Metrics{})
 			if len(m) > 0 {
-				cache <- m
+				cache <- metricChunk{source: msg.GetSource(), metrics: m}
 			}
 		})
 	} else {

--- a/pkg/otel/schema.json
+++ b/pkg/otel/schema.json
@@ -10,9 +10,9 @@
         },
         "serviceName": {
             "type": "string",
-            "title": "Service Name",
+            "title": "Fallback Service Name",
             "default": "hermes",
-            "description": "Identifies this source in the collector"
+            "description": "Records are exported with their originating source as service.name. This value is only used when a record has no source."
         },
         "events": {
             "type": "boolean",

--- a/pkg/otel/source_test.go
+++ b/pkg/otel/source_test.go
@@ -1,0 +1,148 @@
+package otel
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+)
+
+type recordingLogExporter struct {
+	mu        sync.Mutex
+	records   []log.Record
+	shutdowns int
+}
+
+func (e *recordingLogExporter) Export(_ context.Context, records []log.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.records = append(e.records, records...)
+	return nil
+}
+
+func (e *recordingLogExporter) Shutdown(context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.shutdowns++
+	return nil
+}
+
+func (e *recordingLogExporter) ForceFlush(context.Context) error { return nil }
+
+func (e *recordingLogExporter) serviceNames() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	names := make([]string, 0, len(e.records))
+	for i := range e.records {
+		res := e.records[i].Resource()
+		names = append(names, resourceServiceName(&res))
+	}
+	return names
+}
+
+func resourceServiceName(res *resource.Resource) string {
+	for _, attr := range res.Attributes() {
+		if attr.Key == semconv.ServiceNameKey {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
+}
+
+func TestResourceCacheUsesSourceAsServiceName(t *testing.T) {
+	// Every record used to carry the profile's static service name, so Loki
+	// labelled all sources "hermes" no matter where the data came from.
+	cache := newResourceCache("hermes")
+
+	res, err := cache.get(context.Background(), "fsw-1")
+	if err != nil {
+		t.Fatalf("failed to build resource: %v", err)
+	}
+
+	if got := resourceServiceName(res); got != "fsw-1" {
+		t.Errorf("service.name = %q, want %q", got, "fsw-1")
+	}
+}
+
+func TestResourceCacheFallsBackWhenSourceIsEmpty(t *testing.T) {
+	cache := newResourceCache("hermes")
+
+	res, err := cache.get(context.Background(), "")
+	if err != nil {
+		t.Fatalf("failed to build resource: %v", err)
+	}
+
+	if got := resourceServiceName(res); got != "hermes" {
+		t.Errorf("service.name = %q, want %q", got, "hermes")
+	}
+}
+
+func TestResourceCacheReusesResourcePerSource(t *testing.T) {
+	cache := newResourceCache("hermes")
+
+	first, err := cache.get(context.Background(), "fsw-1")
+	if err != nil {
+		t.Fatalf("failed to build resource: %v", err)
+	}
+
+	second, err := cache.get(context.Background(), "fsw-1")
+	if err != nil {
+		t.Fatalf("failed to build resource: %v", err)
+	}
+
+	if first != second {
+		t.Error("expected the same resource instance to be reused for a source")
+	}
+}
+
+func TestLogRouterExportsRecordsUnderTheirSource(t *testing.T) {
+	exporter := &recordingLogExporter{}
+	router := newLogRouter(newResourceCache("hermes"), exporter)
+
+	ctx := context.Background()
+	for _, source := range []string{"fsw-1", "fsw-2"} {
+		rec := slog.NewRecord(time.Now(), slog.LevelInfo, "event", 0)
+		if err := router.handle(ctx, source, rec); err != nil {
+			t.Fatalf("failed to handle record for %q: %v", source, err)
+		}
+	}
+
+	router.shutdown(ctx)
+
+	seen := map[string]bool{}
+	for _, name := range exporter.serviceNames() {
+		seen[name] = true
+	}
+
+	for _, want := range []string{"fsw-1", "fsw-2"} {
+		if !seen[want] {
+			t.Errorf("no record exported with service.name %q, got %v", want, exporter.serviceNames())
+		}
+	}
+}
+
+func TestLogRouterShutdownLeavesSharedExporterOpen(t *testing.T) {
+	// Providers share one exporter; letting a provider's batch processor
+	// shut it down would kill exports for every other source.
+	exporter := &recordingLogExporter{}
+	router := newLogRouter(newResourceCache("hermes"), exporter)
+
+	ctx := context.Background()
+	if err := router.handle(ctx, "fsw-1", slog.NewRecord(time.Now(), slog.LevelInfo, "event", 0)); err != nil {
+		t.Fatalf("failed to handle record: %v", err)
+	}
+
+	router.shutdown(ctx)
+
+	exporter.mu.Lock()
+	defer exporter.mu.Unlock()
+	if exporter.shutdowns != 0 {
+		t.Errorf("shared exporter was shut down %d times by provider shutdown", exporter.shutdowns)
+	}
+}


### PR DESCRIPTION
## Summary
This PR solves source ambiguity issues in two areas: the Hermes Datasource Grafana Plugin, and the OTEL Profile Provider.
### Grafana
The datasource would only populate sources across the last 24 hours, regardless of the currently selected dashboard timeframe (or absolute time customizations). This limit is now removed and the plugin will display all sources across time using `SELECT DISTINCT`.

Testing of sources has surfaced two other issues:
- #234 
- #235
### OTEL Provider
In the current implementation, the service name was hardcoded to the name provided in the provider UI "service name." This resulted in Loki effectively not receiving sourced data properly and always displaying EVRs as coming from the provided source. The provider now has structures in place to export the source with the data into another service name (using the service name in the UI as a fallback if no source is provided on an EVR).
## Screenshots
<img width="969" height="534" alt="Screenshot 2026-08-28 at 1 34 40 PM" src="https://github.com/user-attachments/assets/f0e19cc2-dee9-4459-82b0-7d18a2bddc1e" />

## Issues
Closes #233 